### PR TITLE
Enable simple Turkish profanity filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,6 @@ gradle test
 
 ## Configuration
 The plugin generates `config.yml` on first run. Insert your OpenAI API key and adjust thresholds or punishments as needed.
+The service now uses OpenAI's `omni-moderation-latest` model by default.
 You can also define `blocked-words` for custom profanity detection. Any chat message
 containing one of these words will be muted without an API call.

--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ gradle test
 
 ## Configuration
 The plugin generates `config.yml` on first run. Insert your OpenAI API key and adjust thresholds or punishments as needed.
+You can also define `blocked-words` for custom profanity detection. Any chat message
+containing one of these words will be muted without an API call.

--- a/src/main/java/me/ogulcan/chatmod/service/ModerationService.java
+++ b/src/main/java/me/ogulcan/chatmod/service/ModerationService.java
@@ -16,6 +16,7 @@ import java.util.logging.Logger;
 
 public class ModerationService {
     private static final String URL = "https://api.openai.com/v1/moderations";
+    private static final String MODEL = "omni-moderation-latest";
     private final OkHttpClient client = new OkHttpClient();
     private final Gson gson = new Gson();
     private final String apiKey;
@@ -110,6 +111,7 @@ public class ModerationService {
     }
 
     private static class Payload {
+        final String model = MODEL;
         final String input;
         Payload(String input) { this.input = input; }
     }

--- a/src/main/java/me/ogulcan/chatmod/service/WordFilter.java
+++ b/src/main/java/me/ogulcan/chatmod/service/WordFilter.java
@@ -1,0 +1,16 @@
+package me.ogulcan.chatmod.service;
+
+import java.util.List;
+
+public class WordFilter {
+    public static boolean containsBlockedWord(String message, List<String> blockedWords) {
+        if (message == null) return false;
+        String lower = message.toLowerCase();
+        for (String w : blockedWords) {
+            if (lower.contains(w.toLowerCase())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -10,3 +10,11 @@ blocked-categories:
   - hate
   - sexual
 rate-limit: 60
+blocked-words:
+  - amk
+  - orospu
+  - pic
+  - sik
+  - yarak
+  - got
+  - amina

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,5 @@
 openai-key: "REPLACE_ME"
+model: omni-moderation-latest
 threshold: 0.5
 punishments:
   first: 5

--- a/src/test/java/me/ogulcan/chatmod/service/WordFilterTest.java
+++ b/src/test/java/me/ogulcan/chatmod/service/WordFilterTest.java
@@ -1,0 +1,20 @@
+package me.ogulcan.chatmod.service;
+
+import org.junit.jupiter.api.Test;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class WordFilterTest {
+    @Test
+    public void testDetectsBlockedWord() {
+        List<String> words = List.of("orospu", "piç");
+        assertTrue(WordFilter.containsBlockedWord("Sen bir orospu çocuğusun", words));
+    }
+
+    @Test
+    public void testIgnoresCleanMessage() {
+        List<String> words = List.of("orospu", "piç");
+        assertFalse(WordFilter.containsBlockedWord("Merhaba nasılsın", words));
+    }
+}


### PR DESCRIPTION
## Summary
- add a `WordFilter` helper and tests
- detect `blocked-words` in `ChatListener`
- document `blocked-words` in README
- include sample Turkish slurs in `config.yml`

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_684d33486dfc8330ade01363f35bd6ac