### PR TITLE
Add configurable word filter toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,5 @@ gradle test
 The plugin generates `config.yml` on first run. Insert your OpenAI API key and adjust thresholds or punishments as needed.
 The service now uses OpenAI's `omni-moderation-latest` model by default.
 You can also define `blocked-words` for custom profanity detection. Any chat message
-containing one of these words will be muted without an API call.
+containing one of these words will be muted without an API call. Set `use-blocked-words`
+to `false` to disable this list-based filter and rely solely on the OpenAI model.

--- a/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
+++ b/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
@@ -23,6 +23,7 @@ public class ChatListener implements Listener {
     private final PunishmentStore store;
     private final List<String> categories;
     private final List<String> words;
+    private final boolean useBlockedWords;
 
     public ChatListener(Main plugin, ModerationService service, PunishmentStore store) {
         this.plugin = plugin;
@@ -30,6 +31,7 @@ public class ChatListener implements Listener {
         this.store = store;
         this.categories = plugin.getConfig().getStringList("blocked-categories");
         this.words = plugin.getConfig().getStringList("blocked-words");
+        this.useBlockedWords = plugin.getConfig().getBoolean("use-blocked-words", true);
     }
 
     @EventHandler
@@ -43,7 +45,7 @@ public class ChatListener implements Listener {
             return;
         }
         String message = event.getMessage();
-        if (WordFilter.containsBlockedWord(message, words)) {
+        if (useBlockedWords && WordFilter.containsBlockedWord(message, words)) {
             Bukkit.getScheduler().runTask(plugin, () -> applyPunishment(player));
             return;
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -11,6 +11,7 @@ blocked-categories:
   - hate
   - sexual
 rate-limit: 60
+use-blocked-words: true
 blocked-words:
   - amk
   - orospu


### PR DESCRIPTION
## Summary
- make local `blocked-words` filter optional via new `use-blocked-words` flag
- document the new option in README
- update default `config.yml` with `use-blocked-words: true`

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_684d38bce0f88330a0ed07a7edfd12b2