### PR TITLE
Add /cm help command with bilingual support

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -11,4 +11,7 @@ Belirtilen oyuncunun mevcut susturma cezasını kaldırır.
 ## /cstatus <oyuncu>
 Oyuncunun susturma durumunu gösterir. Eğer susturulmuşsa kalan süreyi dakika ve saniye olarak bildirir.
 
+## /cm
+Tüm komutların kısa açıklamalarını renkli biçimde listeler.
+
 Ek olarak `chatmoderation.notify` yetkisine sahip olan oyuncular, otomatik susturma durumlarını bildiren uyarıları alır.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ gradle test
 
 ## Configuration
 The plugin generates `config.yml` on first run. Insert your OpenAI API key and adjust thresholds or punishments as needed.
+Set `language` to `en` or `tr` to change plugin messages.
 The service now uses OpenAI's `omni-moderation-latest` model by default.
 All categories supported by this model are included in `blocked-categories`:
 

--- a/src/main/java/me/ogulcan/chatmod/Main.java
+++ b/src/main/java/me/ogulcan/chatmod/Main.java
@@ -3,9 +3,11 @@ package me.ogulcan.chatmod;
 import me.ogulcan.chatmod.command.CMuteCommand;
 import me.ogulcan.chatmod.command.CStatusCommand;
 import me.ogulcan.chatmod.command.CUnmuteCommand;
+import me.ogulcan.chatmod.command.CmCommand;
 import me.ogulcan.chatmod.listener.ChatListener;
 import me.ogulcan.chatmod.service.ModerationService;
 import me.ogulcan.chatmod.storage.PunishmentStore;
+import me.ogulcan.chatmod.util.Messages;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
@@ -13,10 +15,13 @@ import java.io.File;
 public class Main extends JavaPlugin {
     private ModerationService moderationService;
     private PunishmentStore store;
+    private Messages messages;
 
     @Override
     public void onEnable() {
         saveDefaultConfig();
+        String lang = getConfig().getString("language", "en");
+        this.messages = new Messages(lang);
         String apiKey = getConfig().getString("openai-key", "");
         double threshold = getConfig().getDouble("threshold", 0.5);
         int rateLimit = getConfig().getInt("rate-limit", 60);
@@ -26,10 +31,15 @@ public class Main extends JavaPlugin {
 
         getCommand("cmute").setExecutor(new CMuteCommand(store, this));
         getCommand("cunmute").setExecutor(new CUnmuteCommand(store, this));
-        getCommand("cstatus").setExecutor(new CStatusCommand(store));
+        getCommand("cstatus").setExecutor(new CStatusCommand(store, this));
+        getCommand("cm").setExecutor(new CmCommand(this));
     }
 
     public PunishmentStore getStore() {
         return store;
+    }
+
+    public Messages getMessages() {
+        return messages;
     }
 }

--- a/src/main/java/me/ogulcan/chatmod/command/CMuteCommand.java
+++ b/src/main/java/me/ogulcan/chatmod/command/CMuteCommand.java
@@ -1,22 +1,20 @@
 package me.ogulcan.chatmod.command;
 
+import me.ogulcan.chatmod.Main;
 import me.ogulcan.chatmod.storage.PunishmentStore;
 import me.ogulcan.chatmod.task.UnmuteTask;
-import org.bukkit.plugin.Plugin;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.Plugin;
 
 import java.util.UUID;
 
 public class CMuteCommand implements CommandExecutor {
     private final PunishmentStore store;
-    private final Plugin plugin;
-    public CMuteCommand(PunishmentStore store, Plugin plugin) {
+    private final Main plugin;
+    public CMuteCommand(PunishmentStore store, Main plugin) {
         this.store = store;
         this.plugin = plugin;
     }
@@ -26,19 +24,19 @@ public class CMuteCommand implements CommandExecutor {
         if (args.length < 2) return false;
         Player target = Bukkit.getPlayer(args[0]);
         if (target == null) {
-            sender.sendMessage(ChatColor.RED + "Player not found.");
+            sender.sendMessage(plugin.getMessages().get("player-not-found"));
             return true;
         }
         long minutes;
         try {
             minutes = Long.parseLong(args[1]);
         } catch (NumberFormatException e) {
-            sender.sendMessage(ChatColor.RED + "Invalid minutes.");
+            sender.sendMessage(plugin.getMessages().get("invalid-minutes"));
             return true;
         }
         store.mute(target.getUniqueId(), minutes);
         new UnmuteTask(plugin, target.getUniqueId(), store).runTaskLater(plugin, minutes * 60L * 20L);
-        sender.sendMessage(ChatColor.GREEN + "Muted " + target.getName() + " for " + minutes + " minutes.");
+        sender.sendMessage(plugin.getMessages().get("muted", target.getName(), minutes));
         return true;
     }
 }

--- a/src/main/java/me/ogulcan/chatmod/command/CStatusCommand.java
+++ b/src/main/java/me/ogulcan/chatmod/command/CStatusCommand.java
@@ -1,8 +1,8 @@
 package me.ogulcan.chatmod.command;
 
+import me.ogulcan.chatmod.Main;
 import me.ogulcan.chatmod.storage.PunishmentStore;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -10,9 +10,11 @@ import org.bukkit.entity.Player;
 
 public class CStatusCommand implements CommandExecutor {
     private final PunishmentStore store;
+    private final Main plugin;
 
-    public CStatusCommand(PunishmentStore store) {
+    public CStatusCommand(PunishmentStore store, Main plugin) {
         this.store = store;
+        this.plugin = plugin;
     }
 
     @Override
@@ -20,14 +22,14 @@ public class CStatusCommand implements CommandExecutor {
         if (args.length < 1) return false;
         Player target = Bukkit.getPlayer(args[0]);
         if (target == null) {
-            sender.sendMessage(ChatColor.RED + "Player not found.");
+            sender.sendMessage(plugin.getMessages().get("player-not-found"));
             return true;
         }
         if (store.isMuted(target.getUniqueId())) {
             long rem = store.remaining(target.getUniqueId()) / 1000;
-            sender.sendMessage(ChatColor.YELLOW + target.getName() + " remaining mute: " + (rem/60) + "m" + (rem%60) + "s");
+            sender.sendMessage(plugin.getMessages().get("remaining-mute", target.getName(), rem/60, rem%60));
         } else {
-            sender.sendMessage(ChatColor.GREEN + target.getName() + " is not muted.");
+            sender.sendMessage(plugin.getMessages().get("not-muted", target.getName()));
         }
         return true;
     }

--- a/src/main/java/me/ogulcan/chatmod/command/CUnmuteCommand.java
+++ b/src/main/java/me/ogulcan/chatmod/command/CUnmuteCommand.java
@@ -1,19 +1,18 @@
 package me.ogulcan.chatmod.command;
 
+import me.ogulcan.chatmod.Main;
 import me.ogulcan.chatmod.storage.PunishmentStore;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.Plugin;
 
 public class CUnmuteCommand implements CommandExecutor {
     private final PunishmentStore store;
-    private final Plugin plugin;
+    private final Main plugin;
 
-    public CUnmuteCommand(PunishmentStore store, Plugin plugin) {
+    public CUnmuteCommand(PunishmentStore store, Main plugin) {
         this.store = store;
         this.plugin = plugin;
     }
@@ -23,11 +22,11 @@ public class CUnmuteCommand implements CommandExecutor {
         if (args.length < 1) return false;
         Player target = Bukkit.getPlayer(args[0]);
         if (target == null) {
-            sender.sendMessage(ChatColor.RED + "Player not found.");
+            sender.sendMessage(plugin.getMessages().get("player-not-found"));
             return true;
         }
         store.unmute(target.getUniqueId());
-        sender.sendMessage(ChatColor.GREEN + "Unmuted " + target.getName() + ".");
+        sender.sendMessage(plugin.getMessages().get("unmuted", target.getName()));
         return true;
     }
 }

--- a/src/main/java/me/ogulcan/chatmod/command/CmCommand.java
+++ b/src/main/java/me/ogulcan/chatmod/command/CmCommand.java
@@ -1,0 +1,23 @@
+package me.ogulcan.chatmod.command;
+
+import me.ogulcan.chatmod.Main;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+public class CmCommand implements CommandExecutor {
+    private final Main plugin;
+
+    public CmCommand(Main plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        sender.sendMessage(plugin.getMessages().get("commands-title"));
+        sender.sendMessage(plugin.getMessages().get("command-cmute"));
+        sender.sendMessage(plugin.getMessages().get("command-cunmute"));
+        sender.sendMessage(plugin.getMessages().get("command-cstatus"));
+        return true;
+    }
+}

--- a/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
+++ b/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
@@ -6,7 +6,6 @@ import me.ogulcan.chatmod.service.WordFilter;
 import me.ogulcan.chatmod.storage.PunishmentStore;
 import me.ogulcan.chatmod.task.UnmuteTask;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -40,7 +39,7 @@ public class ChatListener implements Listener {
         UUID uuid = player.getUniqueId();
         if (store.isMuted(uuid)) {
             long rem = store.remaining(uuid) / 1000;
-            player.sendMessage(ChatColor.RED + "You are muted for " + format(rem) + ".");
+            player.sendMessage(plugin.getMessages().get("still-muted", format(rem)));
             event.setCancelled(true);
             return;
         }
@@ -69,14 +68,14 @@ public class ChatListener implements Listener {
             minutes = plugin.getConfig().getLong("punishments.third", 1440);
         } else {
             minutes = plugin.getConfig().getLong("punishments.fourth", 10080);
-            String msg = ChatColor.RED + player.getName() + " has been muted for repeated offences.";
+            String msg = plugin.getMessages().get("repeated-offence", player.getName());
             Bukkit.getOnlinePlayers().stream()
                     .filter(p -> p.hasPermission("chatmoderation.notify"))
                     .forEach(p -> p.sendMessage(msg));
         }
         store.mute(uuid, minutes);
         new UnmuteTask(plugin, uuid, store).runTaskLater(plugin, minutes * 60L * 20L);
-        player.sendMessage(ChatColor.RED + "You have been muted for " + minutes + " minutes.");
+        player.sendMessage(plugin.getMessages().get("muted-player", minutes));
     }
 
     private String format(long seconds) {

--- a/src/main/java/me/ogulcan/chatmod/util/Messages.java
+++ b/src/main/java/me/ogulcan/chatmod/util/Messages.java
@@ -1,0 +1,24 @@
+package me.ogulcan.chatmod.util;
+
+import org.bukkit.ChatColor;
+
+import java.text.MessageFormat;
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+public class Messages {
+    private final ResourceBundle bundle;
+
+    public Messages(String lang) {
+        Locale locale = Locale.forLanguageTag(lang);
+        this.bundle = ResourceBundle.getBundle("messages", locale);
+    }
+
+    public String get(String key, Object... args) {
+        String msg = bundle.getString(key);
+        if (args.length > 0) {
+            msg = MessageFormat.format(msg, args);
+        }
+        return ChatColor.translateAlternateColorCodes('&', msg);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,5 @@
 openai-key: "REPLACE_ME"
+language: en
 model: omni-moderation-latest
 threshold: 0.5
 punishments:

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -1,0 +1,13 @@
+player-not-found=&cPlayer not found.
+invalid-minutes=&cInvalid minutes.
+muted=&aMuted {0} for {1} minutes.
+unmuted=&aUnmuted {0}.
+remaining-mute=&e{0} remaining mute: {1}m{2}s
+not-muted=&a{0} is not muted.
+muted-player=&cYou have been muted for {0} minutes.
+still-muted=&cYou are muted for {0}.
+repeated-offence=&c{0} has been muted for repeated offences.
+commands-title=&aChatModeration Commands:
+command-cmute=&e/cmute <player> <minutes> &7- Mute a player
+command-cunmute=&e/cunmute <player> &7- Unmute a player
+command-cstatus=&e/cstatus <player> &7- Check mute status

--- a/src/main/resources/messages_tr.properties
+++ b/src/main/resources/messages_tr.properties
@@ -1,0 +1,13 @@
+player-not-found=&cOyuncu bulunamad\u0131.
+invalid-minutes=&cGe\u00e7ersiz dakika.
+muted=&a{0} adl\u0131 oyuncu {1} dakika susturuldu.
+unmuted=&a{0} adl\u0131 oyuncunun susturmas\u0131 kald\u0131r\u0131ld\u0131.
+remaining-mute=&e{0} kalan susturma: {1}m{2}s
+not-muted=&a{0} susturulmam\u0131\u015f.
+muted-player=&c{0} dakika susturuldun.
+still-muted=&c{0} boyunca susturuldun.
+repeated-offence=&c{0} tekrar eden ihlaller i\u00e7in susturuldu.
+commands-title=&aChatModeration Komutlar\u0131:
+command-cmute=&e/cmute <oyuncu> <dakika> &7- Oyuncuyu sustur
+command-cunmute=&e/cunmute <oyuncu> &7- Susturmay\u0131 kald\u0131r
+command-cstatus=&e/cstatus <oyuncu> &7- Susturma durumunu g\u00f6ster

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -10,6 +10,8 @@ commands:
     permission: chatmoderation.command
   cstatus:
     permission: chatmoderation.command
+  cm:
+    permission: chatmoderation.command
 permissions:
   chatmoderation.command:
     description: Allows moderation commands


### PR DESCRIPTION
## Summary
- add language choice with new Messages utility
- add `/cm` command for colorful help output
- translate command and listener messages via language files
- document language option in README and command list in COMMANDS.md

## Testing
- `gradle wrapper`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684d6063c1448330b012ed43f4490e77