### PR TITLE
Fix GUI event handling when switching menus

### DIFF
--- a/src/main/java/me/ogulcan/chatmod/gui/DashboardGUI.java
+++ b/src/main/java/me/ogulcan/chatmod/gui/DashboardGUI.java
@@ -11,6 +11,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.HandlerList;
 import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -135,9 +136,9 @@ public class DashboardGUI implements Listener {
 
     @EventHandler
     public void onClose(InventoryCloseEvent e) {
-        if (e.getPlayer() == viewer) {
-            InventoryClickEvent.getHandlerList().unregister(this);
-            InventoryCloseEvent.getHandlerList().unregister(this);
+        if (e.getPlayer() == viewer
+                && e.getReason() != InventoryCloseEvent.Reason.OPEN_NEW) {
+            HandlerList.unregisterAll(this);
         }
     }
 


### PR DESCRIPTION
## Summary
- stop unregistering GUI listener when a new menu opens

## Testing
- `gradle wrapper`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684d71c2b9288330a48b781bac6f3a2f