### PR TITLE
Improve WordFilter normalization

### DIFF
--- a/src/main/java/me/ogulcan/chatmod/service/WordFilter.java
+++ b/src/main/java/me/ogulcan/chatmod/service/WordFilter.java
@@ -8,11 +8,12 @@ import java.util.regex.Pattern;
 public class WordFilter {
 
     private static final Pattern DIACRITICS = Pattern.compile("\\p{M}");
+    private static final Pattern NON_ALNUM = Pattern.compile("[^\\p{L}\\p{Nd}]");
 
     /**
      * Normalize text by converting to lowercase, replacing common Turkish
-     * characters with their ASCII equivalents and stripping any remaining
-     * diacritics.
+     * characters with their ASCII equivalents, stripping any remaining
+     * diacritics and removing whitespace or punctuation.
      */
     private static String normalize(String text) {
         if (text == null) return "";
@@ -24,7 +25,8 @@ public class WordFilter {
                 .replace('ç', 'c')
                 .replace('ı', 'i');
         String nfd = Normalizer.normalize(lower, Normalizer.Form.NFD);
-        return DIACRITICS.matcher(nfd).replaceAll("");
+        String withoutDiacritics = DIACRITICS.matcher(nfd).replaceAll("");
+        return NON_ALNUM.matcher(withoutDiacritics).replaceAll("");
     }
 
     public static boolean containsBlockedWord(String message, List<String> blockedWords) {

--- a/src/test/java/me/ogulcan/chatmod/service/WordFilterTest.java
+++ b/src/test/java/me/ogulcan/chatmod/service/WordFilterTest.java
@@ -23,4 +23,16 @@ public class WordFilterTest {
         List<String> words = List.of("sikeyim");
         assertTrue(WordFilter.containsBlockedWord("s\u0131key\u0131m", words));
     }
+
+    @Test
+    public void testDetectsWordWithSpaces() {
+        List<String> words = List.of("sikeyim");
+        assertTrue(WordFilter.containsBlockedWord("s i k e y i m", words));
+    }
+
+    @Test
+    public void testDetectsWordWithSpecialChars() {
+        List<String> words = List.of("sikeyim");
+        assertTrue(WordFilter.containsBlockedWord("s*i+k(e)y!i%m", words));
+    }
 }


### PR DESCRIPTION
## Summary
- strip non-alphanumeric characters when normalizing chat messages
- verify detection with spaces or special characters in new tests

## Testing
- `gradle wrapper`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684d882bdd5483308d8e0832e2004a68