### PR TITLE
Add model configuration and startup log

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ The plugin generates `config.yml` on first run. **You must replace** the `openai
 value with your own API key or moderation requests will be skipped. Adjust
 thresholds or punishments as needed.
 Set `language` to `en` or `tr` to change plugin messages. The selected language file (`messages_en.yml` or `messages_tr.yml`) will be copied to the plugin folder so you can edit any text.
-Enable `debug: true` in `config.yml` to log moderation responses for troubleshooting.
-The service now uses OpenAI's `omni-moderation-latest` model by default.
+Enable `debug: true` in `config.yml` to log moderation responses and the selected moderation model for troubleshooting.
+The `model` option defaults to OpenAI's `omni-moderation-latest`, but you may set it to any supported model.
 All categories supported by this model are included in `blocked-categories`:
 
 ```

--- a/src/main/java/me/ogulcan/chatmod/Main.java
+++ b/src/main/java/me/ogulcan/chatmod/Main.java
@@ -37,11 +37,12 @@ public class Main extends JavaPlugin {
         String apiKey = getConfig().getString("openai-key", "");
         double threshold = getConfig().getDouble("threshold", 0.5);
         int rateLimit = getConfig().getInt("rate-limit", 60);
+        String model = getConfig().getString("model", "omni-moderation-latest");
         boolean debug = getConfig().getBoolean("debug", false);
         if (debug) {
             getLogger().info("Debug mode enabled");
         }
-        this.moderationService = new ModerationService(apiKey, threshold, rateLimit, this.getLogger(), debug);
+        this.moderationService = new ModerationService(apiKey, model, threshold, rateLimit, this.getLogger(), debug);
         this.store = new PunishmentStore(new File(getDataFolder(), "data/punishments.json"));
         getServer().getPluginManager().registerEvents(new ChatListener(this, moderationService, store), this);
 

--- a/src/main/java/me/ogulcan/chatmod/service/ModerationService.java
+++ b/src/main/java/me/ogulcan/chatmod/service/ModerationService.java
@@ -16,13 +16,14 @@ import java.util.logging.Logger;
 
 public class ModerationService {
     private static final String URL = "https://api.openai.com/v1/moderations";
-    private static final String MODEL = "omni-moderation-latest";
+    private static final String DEFAULT_MODEL = "omni-moderation-latest";
     private final OkHttpClient client = new OkHttpClient();
     private final Gson gson = new Gson();
     private final String apiKey;
     private final double threshold;
     private final int rateLimit;
     private final Logger logger;
+    private final String model;
     private final boolean enabled;
     private final boolean debug;
     private Instant window = Instant.now();
@@ -32,8 +33,9 @@ public class ModerationService {
         return URL;
     }
 
-    public ModerationService(String apiKey, double threshold, int rateLimit, Logger logger, boolean debug) {
+    public ModerationService(String apiKey, String model, double threshold, int rateLimit, Logger logger, boolean debug) {
         this.apiKey = apiKey;
+        this.model = (model == null || model.isBlank()) ? DEFAULT_MODEL : model;
         this.threshold = threshold;
         this.rateLimit = rateLimit;
         this.logger = logger;
@@ -41,6 +43,9 @@ public class ModerationService {
         this.enabled = apiKey != null && !apiKey.isBlank() && !"REPLACE_ME".equals(apiKey);
         if (!enabled) {
             logger.warning("OpenAI API key missing or not set. Moderation requests will be skipped.");
+        }
+        if (debug) {
+            logger.info("Using moderation model: " + this.model);
         }
     }
 
@@ -136,8 +141,8 @@ public class ModerationService {
         });
     }
 
-    private static class Payload {
-        final String model = MODEL;
+    private class Payload {
+        final String model = ModerationService.this.model;
         final String input;
         Payload(String input) { this.input = input; }
     }

--- a/src/test/java/me/ogulcan/chatmod/service/ModerationServiceTest.java
+++ b/src/test/java/me/ogulcan/chatmod/service/ModerationServiceTest.java
@@ -21,7 +21,7 @@ public class ModerationServiceTest {
     public void setUp() throws IOException {
         server = new MockWebServer();
         server.start();
-        service = new ModerationService("test", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false) {
+        service = new ModerationService("test", "omni-moderation-latest", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false) {
             @Override
             protected String getUrl() { return server.url("/v1/moderations").toString(); }
         };
@@ -55,7 +55,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testRateLimit() throws Exception {
-        service = new ModerationService("test", 0.5, 1, java.util.logging.Logger.getAnonymousLogger(), false) {
+        service = new ModerationService("test", "omni-moderation-latest", 0.5, 1, java.util.logging.Logger.getAnonymousLogger(), false) {
             @Override
             protected String getUrl() { return server.url("/v1/moderations").toString(); }
         };
@@ -75,7 +75,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testDisabledWhenNoApiKey() throws Exception {
-        ModerationService disabled = new ModerationService("", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false);
+        ModerationService disabled = new ModerationService("", "omni-moderation-latest", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false);
         ModerationService.Result r = disabled.moderate("whatever").get();
         assertFalse(r.triggered);
     }


### PR DESCRIPTION
## Summary
- allow specifying OpenAI moderation model in config
- log the model being used when debug mode is enabled
- adjust tests for new ModerationService constructor
- mention configurable model in README

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684d8a7d988c8330a6752a155f92a83d