### PR TITLE
Add 1.20.x support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,8 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.21-R0.1-SNAPSHOT")
+    // Compile against the latest 1.20.x API for broader server compatibility
+    compileOnly("io.papermc.paper:paper-api:1.20.6-R0.1-SNAPSHOT")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("com.google.code.gson:gson:2.10.1")
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: ChatModeration
 version: 0.1.0
 main: me.ogulcan.chatmod.Main
 author: ogulcan
-api-version: "1.21"
+api-version: "1.20"
 commands:
   cm:
     permission: chatmoderation.command


### PR DESCRIPTION
## Summary
- compile against Paper 1.20.6 API
- lower API version in plugin.yml

## Testing
- `gradle wrapper --gradle-version 8.7`
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684d913a047483309d7fafb58e281153