### PR TITLE
Adjust default rate limit

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -21,7 +21,7 @@ blocked-categories:
   - sexual/minors
   - violence
   - violence/graphic
-rate-limit: 60
+rate-limit: 250
 debug: false
 countdown-offline: true
 use-blocked-words: true


### PR DESCRIPTION
## Summary
- raise `rate-limit` in `config.yml` from 60 to 250 for higher throughput

## Testing
- `gradle wrapper`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684da4de27e48330a9cdb1d1549a5bd2