### PR TITLE
Toggle OpenAI warnings with debug flag

### DIFF
--- a/src/main/java/me/ogulcan/chatmod/service/ModerationService.java
+++ b/src/main/java/me/ogulcan/chatmod/service/ModerationService.java
@@ -87,8 +87,8 @@ public class ModerationService {
         client.newCall(request).enqueue(new Callback() {
             @Override
             public void onFailure(Call call, IOException e) {
-                logger.log(Level.WARNING, "Moderation request failed", e);
                 if (debug) {
+                    logger.log(Level.WARNING, "Moderation request failed", e);
                     logger.info("Retrying in debug mode, attempt " + attempt);
                 }
                 if (attempt < 2) {
@@ -108,8 +108,8 @@ public class ModerationService {
                                     .execute(() -> sendRequest(message, future, attempt + 1));
                             return;
                         }
-                        logger.warning("OpenAI error: " + response.code());
                         if (debug) {
+                            logger.warning("OpenAI error: " + response.code());
                             logger.info("Response body: " + (rb != null ? rb.string() : "null"));
                         }
                         future.complete(new Result(false, false, new HashMap<>()));


### PR DESCRIPTION
## Summary
- show OpenAI moderation errors only when `debug` is enabled

## Testing
- `gradle wrapper`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684da7e9af7883308c1f5a2fb52904c2