### PR TITLE
Block /msg for muted players

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ thresholds or punishments as needed.
 Set `language` to `en` or `tr` to change plugin messages. The selected language file (`messages_en.yml` or `messages_tr.yml`) will be copied to the plugin folder so you can edit any text.
 Enable `debug: true` in `config.yml` to log moderation responses and the selected moderation model for troubleshooting.
 Set `countdown-offline` to `false` if you want mute timers to pause while muted players are offline.
+Muted players are also blocked from using private messaging commands like `/msg`.
 The `model` option defaults to OpenAI's `omni-moderation-latest`, but you may set it to any supported model.
 All categories supported by this model are included in `blocked-categories`:
 

--- a/src/main/java/me/ogulcan/chatmod/Main.java
+++ b/src/main/java/me/ogulcan/chatmod/Main.java
@@ -3,6 +3,7 @@ package me.ogulcan.chatmod;
 import me.ogulcan.chatmod.command.CmCommand;
 import me.ogulcan.chatmod.listener.ChatListener;
 import me.ogulcan.chatmod.listener.PlayerListener;
+import me.ogulcan.chatmod.listener.PrivateMessageListener;
 import me.ogulcan.chatmod.service.ModerationService;
 import me.ogulcan.chatmod.storage.PunishmentStore;
 import me.ogulcan.chatmod.util.Messages;
@@ -52,6 +53,7 @@ public class Main extends JavaPlugin {
         this.store = new PunishmentStore(new File(getDataFolder(), "data/punishments.json"));
         getServer().getPluginManager().registerEvents(new ChatListener(this, moderationService, store), this);
         getServer().getPluginManager().registerEvents(new PlayerListener(this, store), this);
+        getServer().getPluginManager().registerEvents(new PrivateMessageListener(this, store), this);
 
         getCommand("cm").setExecutor(new CmCommand(this, store));
     }

--- a/src/main/java/me/ogulcan/chatmod/listener/PrivateMessageListener.java
+++ b/src/main/java/me/ogulcan/chatmod/listener/PrivateMessageListener.java
@@ -1,0 +1,50 @@
+package me.ogulcan.chatmod.listener;
+
+import me.ogulcan.chatmod.Main;
+import me.ogulcan.chatmod.storage.PunishmentStore;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+
+import java.util.Set;
+import java.util.UUID;
+
+public class PrivateMessageListener implements Listener {
+    private final Main plugin;
+    private final PunishmentStore store;
+    private final Set<String> commands = Set.of(
+            "msg", "tell", "w", "whisper", "m", "pm", "r", "reply"
+    );
+
+    public PrivateMessageListener(Main plugin, PunishmentStore store) {
+        this.plugin = plugin;
+        this.store = store;
+    }
+
+    @EventHandler
+    public void onCommand(PlayerCommandPreprocessEvent event) {
+        String label = event.getMessage().substring(1).split(" ")[0].toLowerCase();
+        int colon = label.indexOf(':');
+        if (colon != -1) label = label.substring(colon + 1);
+        if (!commands.contains(label)) return;
+
+        Player player = event.getPlayer();
+        UUID uuid = player.getUniqueId();
+        if (store.isMuted(uuid)) {
+            long rem = store.remaining(uuid) / 1000;
+            player.sendMessage(plugin.getMessages().get("still-muted", format(rem)));
+            event.setCancelled(true);
+        }
+    }
+
+    private String format(long seconds) {
+        long min = seconds / 60;
+        long sec = seconds % 60;
+        String lang = plugin.getConfig().getString("language", "en");
+        if ("tr".equalsIgnoreCase(lang)) {
+            return min + " dakika " + sec + " saniye";
+        }
+        return min + "m " + sec + "s";
+    }
+}


### PR DESCRIPTION
## Summary
- block /msg and similar commands while player is muted
- register the new PrivateMessageListener
- document that private messaging is blocked when muted

## Testing
- `gradle wrapper --gradle-version 8.7`
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684dab9867e4833087a9875132ae766d