### PR TITLE
Add full reload capability

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -12,7 +12,8 @@ Belirtilen oyuncunun mevcut susturma cezasını kaldırır.
 Oyuncunun susturma durumunu gösterir. Eğer susturulmuşsa kalan süreyi dakika ve saniye olarak bildirir.
 
 ## /cm reload
-Yapılandırma ve dil dosyalarını yeniden yükler.
+Tüm ayarları yeniden okuyarak dinleyicileri yeniler. `openai-key`, `model`,
+`threshold` ve `rate-limit` de anında güncellenir.
 
 ## /cm
 Tüm komutların kısa açıklamalarını renkli biçimde listeler.

--- a/README.md
+++ b/README.md
@@ -106,4 +106,6 @@ player:
 Hovering a player's head shows whether they are muted, the remaining time and
 how many offences they had in the last 24&nbsp;hours.
 
-Reload both `config.yml` and `gui.yml` with `/cm reload`.
+Use `/cm reload` to re-read all configuration files. OpenAI options such as
+`openai-key`, `model`, `threshold` and `rate-limit` are applied immediately and
+event listeners are re-registered without restarting the server.

--- a/src/main/java/me/ogulcan/chatmod/command/CmCommand.java
+++ b/src/main/java/me/ogulcan/chatmod/command/CmCommand.java
@@ -99,7 +99,7 @@ public class CmCommand implements CommandExecutor {
     }
 
     private boolean reload(CommandSender sender) {
-        plugin.reloadFiles();
+        plugin.reloadAll();
         sender.sendMessage(plugin.getMessages().get("reloaded"));
         return true;
     }


### PR DESCRIPTION
## Summary
- reload listeners and OpenAI settings when `/cm reload` is executed
- document improved reload behaviour

## Testing
- `gradle wrapper`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684db0148b788330afbf013c8822bc85