### PR TITLE
Improve word filtering tokenization

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,10 @@ containing one of these words will be muted without an API call. Set `use-blocke
 to `false` to disable this list-based filter and rely solely on the OpenAI model.
 The filter normalizes text when matching, converting Turkish letters like
 `ş`, `ö`, `ç`, `ğ`, `ı` and `ü` to their ASCII equivalents and removing other
-diacritics. Variants such as `s\u0131key\u0131m` will therefore match a blocked
-word of `sikeyim`.
+diacritics. Punctuation is converted to spaces so word boundaries are kept.
+Each token is checked against the block list and consecutive single-letter
+tokens are combined, allowing `s i k` to match a blocked word of `sik` while
+"Amin Allah" will not match `amina`.
 
 ### GUI Customization
 A separate `gui.yml` file controls the layout of the `/cm gui` dashboard. You can edit

--- a/src/test/java/me/ogulcan/chatmod/service/WordFilterTest.java
+++ b/src/test/java/me/ogulcan/chatmod/service/WordFilterTest.java
@@ -35,4 +35,10 @@ public class WordFilterTest {
         List<String> words = List.of("sikeyim");
         assertTrue(WordFilter.containsBlockedWord("s*i+k(e)y!i%m", words));
     }
+
+    @Test
+    public void testAminAllahDoesNotMatchAmina() {
+        List<String> words = List.of("amina");
+        assertFalse(WordFilter.containsBlockedWord("Amin Allah", words));
+    }
 }


### PR DESCRIPTION
## Summary
- handle punctuation as spaces and keep tokens when filtering
- join single-character tokens for blocked word detection
- ensure "Amin Allah" isn't flagged by a blocklist entry for "amina"
- document updated behaviour in README

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684db9e3b02883308d104bd4b4bb6789