### PR TITLE
Remove 'amina' from blocked words

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ The filter normalizes text when matching, converting Turkish letters like
 diacritics. Punctuation is converted to spaces so word boundaries are kept.
 Each token is checked against the block list and consecutive single-letter
 tokens are combined, allowing `s i k` to match a blocked word of `sik` while
-"Amin Allah" will not match `amina`.
 
 ### GUI Customization
 A separate `gui.yml` file controls the layout of the `/cm gui` dashboard. You can edit

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -32,4 +32,3 @@ blocked-words:
   - sik
   - yarak
   - got
-  - amina

--- a/src/test/java/me/ogulcan/chatmod/service/WordFilterTest.java
+++ b/src/test/java/me/ogulcan/chatmod/service/WordFilterTest.java
@@ -36,9 +36,4 @@ public class WordFilterTest {
         assertTrue(WordFilter.containsBlockedWord("s*i+k(e)y!i%m", words));
     }
 
-    @Test
-    public void testAminAllahDoesNotMatchAmina() {
-        List<String> words = List.of("amina");
-        assertFalse(WordFilter.containsBlockedWord("Amin Allah", words));
-    }
 }


### PR DESCRIPTION
## Summary
- remove example phrase about `Amin Allah` from README
- drop `amina` from default `blocked-words`
- delete test that ensured "Amin Allah" didn't match `amina`

## Testing
- `gradle wrapper`
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684dbdc114d483308bc9d7676b6a8d98