### PR TITLE
Add toggle for blocked categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ sexual/minors
 violence
 violence/graphic
 ```
+Set `use-blocked-categories` to `false` if you want to ignore this list and only
+apply mutes when the API marks a message as `blocked`.
 You can also define `blocked-words` for custom profanity detection. Any chat message
 containing one of these words will be muted without an API call. Set `use-blocked-words`
 to `false` to disable this list-based filter and rely solely on the OpenAI model.

--- a/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
+++ b/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
@@ -22,6 +22,7 @@ public class ChatListener implements Listener {
     private final List<String> categories;
     private final List<String> words;
     private final boolean useBlockedWords;
+    private final boolean useBlockedCategories;
 
     public ChatListener(Main plugin, ModerationService service, PunishmentStore store) {
         this.plugin = plugin;
@@ -30,6 +31,7 @@ public class ChatListener implements Listener {
         this.categories = plugin.getConfig().getStringList("blocked-categories");
         this.words = plugin.getConfig().getStringList("blocked-words");
         this.useBlockedWords = plugin.getConfig().getBoolean("use-blocked-words", true);
+        this.useBlockedCategories = plugin.getConfig().getBoolean("use-blocked-categories", true);
     }
 
     @EventHandler
@@ -50,7 +52,8 @@ public class ChatListener implements Listener {
         }
         service.moderate(message).thenAccept(result -> {
             if (!result.triggered) return;
-            boolean categoryMatch = result.scores.keySet().stream().anyMatch(categories::contains);
+            boolean categoryMatch = useBlockedCategories &&
+                    result.scores.keySet().stream().anyMatch(categories::contains);
             if (!categoryMatch && !result.blocked) return;
             Bukkit.getScheduler().runTask(plugin, () -> applyPunishment(player));
         });

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -24,6 +24,7 @@ blocked-categories:
 rate-limit: 250
 debug: false
 countdown-offline: true
+use-blocked-categories: true
 use-blocked-words: true
 blocked-words:
   - amk


### PR DESCRIPTION
## Summary
- allow disabling `blocked-categories` checks through new `use-blocked-categories` option
- document this option in README

## Testing
- `gradle wrapper`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_684dbee8a0b88330b2b146cf973e2871