### PR TITLE
Fix threshold usage

### DIFF
--- a/src/main/java/me/ogulcan/chatmod/service/ModerationService.java
+++ b/src/main/java/me/ogulcan/chatmod/service/ModerationService.java
@@ -126,10 +126,11 @@ public class ModerationService {
                     }
                     ModerationResponse.Result r = mr.results[0];
                     Map<String, Double> scores = r.categoryScores;
-                    boolean trigger = r.flagged;
-                    for (String cat : scores.keySet()) {
-                        if (scores.get(cat) >= threshold) {
+                    boolean trigger = r.blocked;
+                    for (double score : scores.values()) {
+                        if (score >= threshold) {
                             trigger = true;
+                            break;
                         }
                     }
                     if (debug) {

--- a/src/test/java/me/ogulcan/chatmod/service/ModerationServiceTest.java
+++ b/src/test/java/me/ogulcan/chatmod/service/ModerationServiceTest.java
@@ -47,6 +47,13 @@ public class ModerationServiceTest {
     }
 
     @Test
+    public void testFlaggedBelowThreshold() throws Exception {
+        server.enqueue(new MockResponse().setBody(response(true, false, 0.3)));
+        ModerationService.Result r = service.moderate("hmm").get();
+        assertFalse(r.triggered);
+    }
+
+    @Test
     public void testBlocked() throws Exception {
         server.enqueue(new MockResponse().setBody(blocked()));
         ModerationService.Result r = service.moderate("bad").get();


### PR DESCRIPTION
## Summary
- fix moderation threshold so results only trigger when category scores exceed the configured value or the message is blocked
- add a test covering flagged results below the threshold

## Testing
- `gradle wrapper`
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684ea7c2c1948330aa332d1e97e26dfa