### PR TITLE
Allow per-category threshold overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ gradle test
 ## Configuration
 The plugin generates `config.yml` on first run. **You must replace** the `openai-key`
 value with your own API key or moderation requests will be skipped. Adjust
-thresholds or punishments as needed.
+thresholds or punishments as needed. You can also override the threshold for
+individual moderation categories using `category-thresholds` in `config.yml`.
 Set `language` to `en` or `tr` to change plugin messages. The selected language file (`messages_en.yml` or `messages_tr.yml`) will be copied to the plugin folder so you can edit any text.
 Enable `debug: true` in `config.yml` to log moderation responses and the selected moderation model for troubleshooting.
 Set `countdown-offline` to `false` if you want mute timers to pause while muted players are offline.

--- a/src/main/java/me/ogulcan/chatmod/Main.java
+++ b/src/main/java/me/ogulcan/chatmod/Main.java
@@ -44,13 +44,19 @@ public class Main extends JavaPlugin {
         this.messages = new Messages(this, lang);
         String apiKey = getConfig().getString("openai-key", "");
         double threshold = getConfig().getDouble("threshold", 0.5);
+        Map<String, Double> categoryThresholds = new HashMap<>();
+        if (getConfig().isConfigurationSection("category-thresholds")) {
+            for (String key : getConfig().getConfigurationSection("category-thresholds").getKeys(false)) {
+                categoryThresholds.put(key, getConfig().getDouble("category-thresholds." + key));
+            }
+        }
         int rateLimit = getConfig().getInt("rate-limit", 60);
         String model = getConfig().getString("model", "omni-moderation-latest");
         boolean debug = getConfig().getBoolean("debug", false);
         if (debug) {
             getLogger().info("Debug mode enabled");
         }
-        this.moderationService = new ModerationService(apiKey, model, threshold, rateLimit, this.getLogger(), debug);
+        this.moderationService = new ModerationService(apiKey, model, threshold, categoryThresholds, rateLimit, this.getLogger(), debug);
         this.store = new PunishmentStore(new File(getDataFolder(), "data/punishments.json"));
         getServer().getPluginManager().registerEvents(new ChatListener(this, moderationService, store), this);
         getServer().getPluginManager().registerEvents(new PlayerListener(this, store), this);
@@ -94,10 +100,16 @@ public class Main extends JavaPlugin {
 
         String apiKey = getConfig().getString("openai-key", "");
         double threshold = getConfig().getDouble("threshold", 0.5);
+        Map<String, Double> categoryThresholds = new HashMap<>();
+        if (getConfig().isConfigurationSection("category-thresholds")) {
+            for (String key : getConfig().getConfigurationSection("category-thresholds").getKeys(false)) {
+                categoryThresholds.put(key, getConfig().getDouble("category-thresholds." + key));
+            }
+        }
         int rateLimit = getConfig().getInt("rate-limit", 60);
         String model = getConfig().getString("model", "omni-moderation-latest");
         boolean debug = getConfig().getBoolean("debug", false);
-        this.moderationService = new ModerationService(apiKey, model, threshold, rateLimit, this.getLogger(), debug);
+        this.moderationService = new ModerationService(apiKey, model, threshold, categoryThresholds, rateLimit, this.getLogger(), debug);
 
         HandlerList.unregisterAll(this);
         getServer().getPluginManager().registerEvents(new ChatListener(this, moderationService, store), this);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,6 +2,11 @@ openai-key: "REPLACE_ME"
 language: en
 model: omni-moderation-latest
 threshold: 0.5
+# Override threshold per category, e.g.:
+# category-thresholds:
+#   harassment: 0.4
+#   hate/threatening: 0.2
+category-thresholds: {}
 punishments:
   first: 5
   second: 30


### PR DESCRIPTION
## Summary
- support specifying OpenAI moderation thresholds per category
- load new `category-thresholds` section from config
- document feature in README and config template

## Testing
- `gradle wrapper --no-daemon`
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684eb0657ce8833096df0034121313b4