### PR TITLE
Add per-category moderation thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ apply mutes when the API marks a message as `blocked`.
 You can also define `blocked-words` for custom profanity detection. Any chat message
 containing one of these words will be muted without an API call. Set `use-blocked-words`
 to `false` to disable this list-based filter and rely solely on the OpenAI model.
+Enable `use-category-thresholds` to apply custom score requirements per category.
+These values are configured under `category-thresholds` and do not replace the
+global `threshold` option.
 The filter normalizes text when matching, converting Turkish letters like
 `ş`, `ö`, `ç`, `ğ`, `ı` and `ü` to their ASCII equivalents and removing other
 diacritics. Punctuation is converted to spaces so word boundaries are kept.

--- a/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
+++ b/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
@@ -12,6 +12,7 @@ import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.configuration.ConfigurationSection;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.Locale;
 
 import java.time.Duration;
 import java.util.List;
@@ -40,7 +41,7 @@ public class ChatListener implements Listener {
         ConfigurationSection section = plugin.getConfig().getConfigurationSection("category-thresholds");
         if (section != null) {
             for (String key : section.getKeys(false)) {
-                this.categoryThresholds.put(key, section.getDouble(key));
+                this.categoryThresholds.put(key.toLowerCase(Locale.ROOT), section.getDouble(key));
             }
         }
     }
@@ -65,7 +66,7 @@ public class ChatListener implements Listener {
             boolean catThresholdTrigger = false;
             if (useCategoryThresholds) {
                 for (Map.Entry<String, Double> e : result.scores.entrySet()) {
-                    Double th = categoryThresholds.get(e.getKey());
+                    Double th = categoryThresholds.get(e.getKey().toLowerCase(Locale.ROOT));
                     if (th != null && e.getValue() >= th) {
                         catThresholdTrigger = true;
                         break;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -26,6 +26,21 @@ debug: false
 countdown-offline: true
 use-blocked-categories: true
 use-blocked-words: true
+use-category-thresholds: false
+category-thresholds:
+  harassment: 0.5
+  harassment/threatening: 0.5
+  hate: 0.5
+  hate/threatening: 0.5
+  illicit: 0.5
+  illicit/violent: 0.5
+  self-harm: 0.5
+  self-harm/intent: 0.5
+  self-harm/instructions: 0.5
+  sexual: 0.5
+  sexual/minors: 0.5
+  violence: 0.5
+  violence/graphic: 0.5
 blocked-words:
   - amk
   - orospu


### PR DESCRIPTION
## Summary
- allow per-category score thresholds for muting
- document the new config option

## Testing
- `gradle wrapper`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684eb3b5242883308e3cf521701ec40d