### PR TITLE
Add chat model moderation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Set `language` to `en` or `tr` to change plugin messages. The selected language 
 Enable `debug: true` in `config.yml` to log moderation responses and the selected moderation model for troubleshooting.
 Set `countdown-offline` to `false` if you want mute timers to pause while muted players are offline.
 Muted players are also blocked from using private messaging commands like `/msg`.
-The `model` option defaults to OpenAI's `omni-moderation-latest`, but you may set it to any supported model.
+The `model` option defaults to OpenAI's `omni-moderation-latest`, but you may set it to any supported model. When `gpt-4.1-mini` is selected the plugin will use the chat completion API with a system prompt to simply answer whether the message contains profanity.
 All categories supported by this model are included in `blocked-categories`:
 
 ```

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,6 @@
 openai-key: "REPLACE_ME"
 language: en
+# Set to `gpt-4.1-mini` to use the chat model with a profanity check prompt
 model: omni-moderation-latest
 threshold: 0.5
 punishments:


### PR DESCRIPTION
## Summary
- support `gpt-4.1-mini` via chat completion API
- log which moderation approach is in use
- document chat model usage in README and config
- test new chat path

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_684efef0c0fc8330aa613654931e993c