### PR TITLE
Add configurable chat prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Enable `debug: true` in `config.yml` to log moderation responses and the selecte
 Set `countdown-offline` to `false` if you want mute timers to pause while muted players are offline.
 Muted players are also blocked from using private messaging commands like `/msg`.
 The `model` option defaults to OpenAI's `omni-moderation-latest`, but you may set it to any supported model. When `gpt-4.1-mini` is selected the plugin will use the chat completion API with a system prompt to simply answer whether the message contains profanity.
+You can customize this system prompt via the `chat-prompt` option if you need different wording.
 All categories supported by this model are included in `blocked-categories`:
 
 ```

--- a/src/main/java/me/ogulcan/chatmod/Main.java
+++ b/src/main/java/me/ogulcan/chatmod/Main.java
@@ -46,11 +46,12 @@ public class Main extends JavaPlugin {
         double threshold = getConfig().getDouble("threshold", 0.5);
         int rateLimit = getConfig().getInt("rate-limit", 60);
         String model = getConfig().getString("model", "omni-moderation-latest");
+        String prompt = getConfig().getString("chat-prompt", me.ogulcan.chatmod.service.ModerationService.DEFAULT_SYSTEM_PROMPT);
         boolean debug = getConfig().getBoolean("debug", false);
         if (debug) {
             getLogger().info("Debug mode enabled");
         }
-        this.moderationService = new ModerationService(apiKey, model, threshold, rateLimit, this.getLogger(), debug);
+        this.moderationService = new ModerationService(apiKey, model, threshold, rateLimit, this.getLogger(), debug, prompt);
         this.store = new PunishmentStore(new File(getDataFolder(), "data/punishments.json"));
         getServer().getPluginManager().registerEvents(new ChatListener(this, moderationService, store), this);
         getServer().getPluginManager().registerEvents(new PlayerListener(this, store), this);
@@ -96,8 +97,9 @@ public class Main extends JavaPlugin {
         double threshold = getConfig().getDouble("threshold", 0.5);
         int rateLimit = getConfig().getInt("rate-limit", 60);
         String model = getConfig().getString("model", "omni-moderation-latest");
+        String prompt = getConfig().getString("chat-prompt", me.ogulcan.chatmod.service.ModerationService.DEFAULT_SYSTEM_PROMPT);
         boolean debug = getConfig().getBoolean("debug", false);
-        this.moderationService = new ModerationService(apiKey, model, threshold, rateLimit, this.getLogger(), debug);
+        this.moderationService = new ModerationService(apiKey, model, threshold, rateLimit, this.getLogger(), debug, prompt);
 
         HandlerList.unregisterAll(this);
         getServer().getPluginManager().registerEvents(new ChatListener(this, moderationService, store), this);

--- a/src/main/java/me/ogulcan/chatmod/service/ModerationService.java
+++ b/src/main/java/me/ogulcan/chatmod/service/ModerationService.java
@@ -18,7 +18,7 @@ public class ModerationService {
     private static final String URL = "https://api.openai.com/v1/moderations";
     private static final String CHAT_URL = "https://api.openai.com/v1/chat/completions";
     private static final String DEFAULT_MODEL = "omni-moderation-latest";
-    private static final String SYSTEM_PROMPT =
+    public static final String DEFAULT_SYSTEM_PROMPT =
             "Bu c\u00fcmlede k\u00fcf\u00fcr veya hakaret varsa sadece var yoksa yok yaz (kullan\u0131c\u0131 k\u00fcf\u00fcr\u00fc gizmelek i\u00e7in \u00f6zel karakrerler veya sans\u00fcrler kullanm\u0131\u015f olabilir dikkat et):";
     private final OkHttpClient client = new OkHttpClient();
     private final Gson gson = new Gson();
@@ -30,6 +30,7 @@ public class ModerationService {
     private final boolean chatModel;
     private final boolean enabled;
     private final boolean debug;
+    private final String systemPrompt;
     private Instant window = Instant.now();
     private int count = 0;
 
@@ -41,10 +42,11 @@ public class ModerationService {
         return CHAT_URL;
     }
 
-    public ModerationService(String apiKey, String model, double threshold, int rateLimit, Logger logger, boolean debug) {
+    public ModerationService(String apiKey, String model, double threshold, int rateLimit, Logger logger, boolean debug, String systemPrompt) {
         this.apiKey = apiKey;
         this.model = (model == null || model.isBlank()) ? DEFAULT_MODEL : model;
         this.chatModel = "gpt-4.1-mini".equalsIgnoreCase(this.model);
+        this.systemPrompt = (systemPrompt == null || systemPrompt.isBlank()) ? DEFAULT_SYSTEM_PROMPT : systemPrompt;
         this.threshold = threshold;
         this.rateLimit = rateLimit;
         this.logger = logger;
@@ -227,7 +229,7 @@ public class ModerationService {
         final int max_tokens = 1;
         ChatPayload(String input) {
             this.messages = new Message[]{
-                    new Message("system", SYSTEM_PROMPT),
+                    new Message("system", systemPrompt),
                     new Message("user", input)
             };
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,6 +2,8 @@ openai-key: "REPLACE_ME"
 language: en
 # Set to `gpt-4.1-mini` to use the chat model with a profanity check prompt
 model: omni-moderation-latest
+# Prompt used by the chat model
+chat-prompt: "Bu cümlede küfür veya hakaret varsa sadece var yoksa yok yaz (kullanıcı küfürü gizmelek için özel karakrerler veya sansürler kullanmış olabilir dikkat et):"
 threshold: 0.5
 punishments:
   first: 5

--- a/src/test/java/me/ogulcan/chatmod/service/ModerationServiceTest.java
+++ b/src/test/java/me/ogulcan/chatmod/service/ModerationServiceTest.java
@@ -21,7 +21,7 @@ public class ModerationServiceTest {
     public void setUp() throws IOException {
         server = new MockWebServer();
         server.start();
-        service = new ModerationService("test", "omni-moderation-latest", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false) {
+        service = new ModerationService("test", "omni-moderation-latest", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT) {
             @Override
             protected String getUrl() { return server.url("/v1/moderations").toString(); }
             @Override
@@ -64,7 +64,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testRateLimit() throws Exception {
-        service = new ModerationService("test", "omni-moderation-latest", 0.5, 1, java.util.logging.Logger.getAnonymousLogger(), false) {
+        service = new ModerationService("test", "omni-moderation-latest", 0.5, 1, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT) {
             @Override
             protected String getUrl() { return server.url("/v1/moderations").toString(); }
         };
@@ -84,14 +84,14 @@ public class ModerationServiceTest {
 
     @Test
     public void testDisabledWhenNoApiKey() throws Exception {
-        ModerationService disabled = new ModerationService("", "omni-moderation-latest", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false);
+        ModerationService disabled = new ModerationService("", "omni-moderation-latest", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT);
         ModerationService.Result r = disabled.moderate("whatever").get();
         assertFalse(r.triggered);
     }
 
     @Test
     public void testChatModelTriggered() throws Exception {
-        service = new ModerationService("test", "gpt-4.1-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false) {
+        service = new ModerationService("test", "gpt-4.1-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -102,7 +102,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelNotTriggered() throws Exception {
-        service = new ModerationService("test", "gpt-4.1-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false) {
+        service = new ModerationService("test", "gpt-4.1-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };


### PR DESCRIPTION
## Summary
- add `chat-prompt` setting to config.yml
- pass the new option to ModerationService and use it in chat payload
- document the option in README
- update unit tests for new constructor

## Testing
- `gradle wrapper`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684f2d8e4fbc83309a8c408f06b3207e