### PR TITLE
Implement bypass permission

### DIFF
--- a/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
+++ b/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
@@ -58,6 +58,7 @@ public class ChatListener implements Listener {
             event.setCancelled(true);
             return;
         }
+        if (player.hasPermission("chatmoderation.bypass")) return;
         String message = event.getMessage();
         if (useBlockedWords && WordFilter.containsBlockedWord(message, words)) {
             Bukkit.getScheduler().runTask(plugin, () -> applyPunishment(player));

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -19,3 +19,6 @@ permissions:
   chatmoderation.admin:
     description: Perform admin actions in the GUI
     default: op
+  chatmoderation.bypass:
+    description: Bypass chat moderation
+    default: op


### PR DESCRIPTION
## Summary
- add `chatmoderation.bypass` permission
- skip moderation for players with this permission

## Testing
- `gradle wrapper`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684f33e384408330a1c85817394bee3c