### PR TITLE
Add chat logs viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ main:
       name-on: "&eAuto-Mute ON"
       name-off: "&eAuto-Mute OFF"
       action: toggle-automute
+    logs:
+      slot: 35
+      material: BOOK_AND_QUILL
+      name: "&eView Logs"
+      action: logs
 player:
   size: 9
   buttons:
@@ -113,6 +118,11 @@ player:
 
 Hovering a player's head shows whether they are muted, the remaining time and
 how many offences they had in the last 24&nbsp;hours.
+
+A new **Logs** button on the dashboard opens a paginated view of recent chat
+logs. Each entry displays the player's head, a snippet of the muted message and
+when it was recorded. These logs are stored in `data/logs.json` and persist even
+if the server runs in offline mode.
 
 Use `/cm reload` to re-read all configuration files. OpenAI options such as
 `openai-key`, `model`, `threshold` and `rate-limit` are applied immediately and

--- a/src/main/java/me/ogulcan/chatmod/Main.java
+++ b/src/main/java/me/ogulcan/chatmod/Main.java
@@ -6,6 +6,7 @@ import me.ogulcan.chatmod.listener.PlayerListener;
 import me.ogulcan.chatmod.listener.PrivateMessageListener;
 import me.ogulcan.chatmod.service.ModerationService;
 import me.ogulcan.chatmod.storage.PunishmentStore;
+import me.ogulcan.chatmod.storage.LogStore;
 import me.ogulcan.chatmod.util.Messages;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.event.HandlerList;
@@ -21,6 +22,7 @@ import java.io.File;
 public class Main extends JavaPlugin {
     private ModerationService moderationService;
     private PunishmentStore store;
+    private LogStore logStore;
     private Messages messages;
     private FileConfiguration guiConfig;
     private boolean autoMute = true;
@@ -53,7 +55,8 @@ public class Main extends JavaPlugin {
         }
         this.moderationService = new ModerationService(apiKey, model, threshold, rateLimit, this.getLogger(), debug, prompt);
         this.store = new PunishmentStore(new File(getDataFolder(), "data/punishments.json"));
-        getServer().getPluginManager().registerEvents(new ChatListener(this, moderationService, store), this);
+        this.logStore = new LogStore(new File(getDataFolder(), "data/logs.json"));
+        getServer().getPluginManager().registerEvents(new ChatListener(this, moderationService, store, logStore), this);
         getServer().getPluginManager().registerEvents(new PlayerListener(this, store), this);
         getServer().getPluginManager().registerEvents(new PrivateMessageListener(this, store), this);
 
@@ -62,6 +65,10 @@ public class Main extends JavaPlugin {
 
     public PunishmentStore getStore() {
         return store;
+    }
+
+    public LogStore getLogStore() {
+        return logStore;
     }
 
     public Messages getMessages() {
@@ -102,7 +109,7 @@ public class Main extends JavaPlugin {
         this.moderationService = new ModerationService(apiKey, model, threshold, rateLimit, this.getLogger(), debug, prompt);
 
         HandlerList.unregisterAll(this);
-        getServer().getPluginManager().registerEvents(new ChatListener(this, moderationService, store), this);
+        getServer().getPluginManager().registerEvents(new ChatListener(this, moderationService, store, logStore), this);
         getServer().getPluginManager().registerEvents(new PlayerListener(this, store), this);
         getServer().getPluginManager().registerEvents(new PrivateMessageListener(this, store), this);
     }

--- a/src/main/java/me/ogulcan/chatmod/gui/DashboardGUI.java
+++ b/src/main/java/me/ogulcan/chatmod/gui/DashboardGUI.java
@@ -2,6 +2,7 @@ package me.ogulcan.chatmod.gui;
 
 import me.ogulcan.chatmod.Main;
 import me.ogulcan.chatmod.storage.PunishmentStore;
+import me.ogulcan.chatmod.gui.LogsGUI;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -159,8 +160,16 @@ public class DashboardGUI implements Listener {
                 }
             } else {
                 ButtonInfo btn = mainButtons.get(slot);
-                if (btn != null && viewer.hasPermission("chatmoderation.admin")) {
-                    switch (btn.action) {
+                if (btn != null) {
+                    if ("logs".equals(btn.action)) {
+                        if (viewer.hasPermission("chatmoderation.logs")) {
+                            openingNew = true;
+                            new LogsGUI(plugin, plugin.getLogStore(), viewer);
+                        } else {
+                            viewer.sendMessage(plugin.getMessages().get("no-permission"));
+                        }
+                    } else if (viewer.hasPermission("chatmoderation.admin")) {
+                        switch (btn.action) {
                         case "reload" -> {
                             plugin.reloadFiles();
                             this.gui = plugin.getGuiConfig();
@@ -181,6 +190,7 @@ public class DashboardGUI implements Listener {
                             createMain();
                             openingNew = true;
                             viewer.openInventory(inventory);
+                        }
                         }
                     }
                 }

--- a/src/main/java/me/ogulcan/chatmod/gui/LogsGUI.java
+++ b/src/main/java/me/ogulcan/chatmod/gui/LogsGUI.java
@@ -1,0 +1,120 @@
+package me.ogulcan.chatmod.gui;
+
+import me.ogulcan.chatmod.Main;
+import me.ogulcan.chatmod.storage.LogStore;
+import me.ogulcan.chatmod.storage.LogStore.LogEntry;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+public class LogsGUI implements Listener {
+    private static final int PAGE_SIZE = 45;
+
+    private final Main plugin;
+    private final LogStore store;
+    private final Player viewer;
+    private Inventory inventory;
+    private int page = 0;
+    private boolean openingNew = false;
+
+    public LogsGUI(Main plugin, LogStore store, Player viewer) {
+        this.plugin = plugin;
+        this.store = store;
+        this.viewer = viewer;
+        openPage(0);
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    private void openPage(int p) {
+        List<LogEntry> all = store.getLogs();
+        int total = (all.size() + PAGE_SIZE - 1) / PAGE_SIZE;
+        if (total == 0) total = 1;
+        this.page = Math.max(0, Math.min(p, total - 1));
+        String title = ChatColor.BLUE + "Logs " + (page + 1) + "/" + total;
+        inventory = Bukkit.createInventory(null, 54, title);
+        int start = page * PAGE_SIZE;
+        for (int i = 0; i < PAGE_SIZE && start + i < all.size(); i++) {
+            LogEntry entry = all.get(all.size() - 1 - (start + i));
+            ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+            SkullMeta meta = (SkullMeta) head.getItemMeta();
+            OfflinePlayer op = Bukkit.getOfflinePlayer(entry.uuid);
+            meta.setOwningPlayer(op);
+            meta.setDisplayName(ChatColor.YELLOW + entry.name);
+            List<String> lore = new ArrayList<>();
+            String msg = entry.message.length() > 30 ? entry.message.substring(0, 30) + "..." : entry.message;
+            lore.add(ChatColor.GRAY + msg);
+            DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
+                    .withZone(ZoneId.systemDefault());
+            lore.add(ChatColor.AQUA + fmt.format(Instant.ofEpochMilli(entry.timestamp)));
+            meta.setLore(lore);
+            head.setItemMeta(meta);
+            inventory.setItem(i, head);
+        }
+        if (page > 0) inventory.setItem(45, item(Material.ARROW, ChatColor.GREEN + "Prev"));
+        if (start + PAGE_SIZE < all.size()) inventory.setItem(53, item(Material.ARROW, ChatColor.GREEN + "Next"));
+        openingNew = true;
+        viewer.openInventory(inventory);
+    }
+
+    private ItemStack item(Material mat, String name) {
+        ItemStack item = new ItemStack(mat);
+        ItemMeta meta = item.getItemMeta();
+        meta.setDisplayName(name);
+        item.setItemMeta(meta);
+        return item;
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent e) {
+        if (e.getWhoClicked() != viewer) return;
+        if (e.getView().getTopInventory().equals(inventory) && e.getRawSlot() < inventory.getSize()) {
+            e.setCancelled(true);
+            if (e.getRawSlot() == 45) {
+                openPage(page - 1);
+            } else if (e.getRawSlot() == 53) {
+                openPage(page + 1);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onDrag(InventoryDragEvent e) {
+        if (e.getWhoClicked() != viewer) return;
+        if (e.getView().getTopInventory().equals(inventory)) {
+            for (int slot : e.getRawSlots()) {
+                if (slot < inventory.getSize()) {
+                    e.setCancelled(true);
+                    break;
+                }
+            }
+        }
+    }
+
+    @EventHandler
+    public void onClose(InventoryCloseEvent e) {
+        if (e.getPlayer() != viewer) return;
+        if (openingNew) {
+            openingNew = false;
+            return;
+        }
+        HandlerList.unregisterAll(this);
+    }
+}

--- a/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
+++ b/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
@@ -4,6 +4,7 @@ import me.ogulcan.chatmod.Main;
 import me.ogulcan.chatmod.service.ModerationService;
 import me.ogulcan.chatmod.service.WordFilter;
 import me.ogulcan.chatmod.storage.PunishmentStore;
+import me.ogulcan.chatmod.storage.LogStore;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -20,6 +21,7 @@ public class ChatListener implements Listener {
     private final Main plugin;
     private final ModerationService service;
     private final PunishmentStore store;
+    private final LogStore logStore;
     private final List<String> categories;
     private final List<String> words;
     private final boolean useBlockedWords;
@@ -27,10 +29,11 @@ public class ChatListener implements Listener {
     private final Map<String, Boolean> categoryEnabled;
     private final Map<String, Double> categoryRatio;
 
-    public ChatListener(Main plugin, ModerationService service, PunishmentStore store) {
+    public ChatListener(Main plugin, ModerationService service, PunishmentStore store, LogStore logStore) {
         this.plugin = plugin;
         this.service = service;
         this.store = store;
+        this.logStore = logStore;
         this.categories = plugin.getConfig().getStringList("blocked-categories");
         this.words = plugin.getConfig().getStringList("blocked-words");
         this.useBlockedWords = plugin.getConfig().getBoolean("use-blocked-words", true);
@@ -61,7 +64,7 @@ public class ChatListener implements Listener {
         if (player.hasPermission("chatmoderation.bypass")) return;
         String message = event.getMessage();
         if (useBlockedWords && WordFilter.containsBlockedWord(message, words)) {
-            Bukkit.getScheduler().runTask(plugin, () -> applyPunishment(player));
+            Bukkit.getScheduler().runTask(plugin, () -> applyPunishment(player, message));
             return;
         }
         service.moderate(message).thenAccept(result -> {
@@ -80,12 +83,12 @@ public class ChatListener implements Listener {
                 }
             }
             if (shouldMute) {
-                Bukkit.getScheduler().runTask(plugin, () -> applyPunishment(player));
+                Bukkit.getScheduler().runTask(plugin, () -> applyPunishment(player, message));
             }
         });
     }
 
-    private void applyPunishment(Player player) {
+    private void applyPunishment(Player player, String message) {
         UUID uuid = player.getUniqueId();
         int offences24h = store.offenceCount(uuid, Duration.ofHours(24).toMillis());
         long minutes;
@@ -103,6 +106,7 @@ public class ChatListener implements Listener {
                     .forEach(p -> p.sendMessage(msg));
         }
         store.mute(uuid, minutes);
+        logStore.add(uuid, player.getName(), message);
         plugin.scheduleUnmute(uuid, minutes * 60L * 20L);
         player.sendMessage(plugin.getMessages().get("muted-player", minutes));
 

--- a/src/main/java/me/ogulcan/chatmod/storage/LogStore.java
+++ b/src/main/java/me/ogulcan/chatmod/storage/LogStore.java
@@ -1,0 +1,70 @@
+package me.ogulcan.chatmod.storage;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.bukkit.Bukkit;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Simple persistent store for chat logs.
+ */
+public class LogStore {
+    private final File file;
+    private final Gson gson = new Gson();
+    private List<LogEntry> logs = new ArrayList<>();
+
+    public LogStore(File file) {
+        this.file = file;
+        if (!file.getParentFile().exists()) file.getParentFile().mkdirs();
+        load();
+    }
+
+    public synchronized void add(UUID uuid, String name, String message) {
+        logs.add(new LogEntry(uuid, name, message, System.currentTimeMillis()));
+        save();
+    }
+
+    /** Returns a copy of all logs in chronological order. */
+    public synchronized List<LogEntry> getLogs() {
+        return new ArrayList<>(logs);
+    }
+
+    private void load() {
+        if (!file.exists()) return;
+        try (FileReader reader = new FileReader(file)) {
+            Type type = new TypeToken<List<LogEntry>>(){}.getType();
+            logs = gson.fromJson(reader, type);
+            if (logs == null) logs = new ArrayList<>();
+        } catch (IOException ignored) {}
+    }
+
+    private void save() {
+        try (FileWriter writer = new FileWriter(file)) {
+            gson.toJson(logs, writer);
+        } catch (IOException e) {
+            Bukkit.getLogger().warning("Could not save logs: " + e.getMessage());
+        }
+    }
+
+    public static class LogEntry {
+        public UUID uuid;
+        public String name;
+        public String message;
+        public long timestamp;
+
+        public LogEntry(UUID uuid, String name, String message, long timestamp) {
+            this.uuid = uuid;
+            this.name = name;
+            this.message = message;
+            this.timestamp = timestamp;
+        }
+    }
+}

--- a/src/main/resources/gui.yml
+++ b/src/main/resources/gui.yml
@@ -19,6 +19,11 @@ main:
       name-on: "&eAuto-Mute ON"
       name-off: "&eAuto-Mute OFF"
       action: toggle-automute
+    logs:
+      slot: 35
+      material: BOOK_AND_QUILL
+      name: "&eView Logs"
+      action: logs
 player:
   size: 9
   buttons:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -22,3 +22,6 @@ permissions:
   chatmoderation.bypass:
     description: Bypass chat moderation
     default: op
+  chatmoderation.logs:
+    description: View chat logs
+    default: op


### PR DESCRIPTION
## Summary
- persist chat logs using `LogStore`
- record offending messages when punishment is applied
- load `LogStore` in `Main`
- add logs button to the dashboard and implement `LogsGUI`
- document log viewer in `README`

## Testing
- `gradle wrapper`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684f550fcd4c8330887f1ba725432c3e