### PR TITLE
Add o4-mini model option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Set `language` to `en` or `tr` to change plugin messages. The selected language 
 Enable `debug: true` in `config.yml` to log moderation responses and the selected moderation model for troubleshooting.
 Set `countdown-offline` to `false` if you want mute timers to pause while muted players are offline.
 Muted players are also blocked from using private messaging commands like `/msg`.
-The `model` option defaults to OpenAI's `omni-moderation-latest`, but you may set it to any supported model. When `gpt-4.1-mini`, `gpt-4.1` or `o3` is selected the plugin will use the chat completion API with a system prompt to simply answer whether the message contains profanity.
+The `model` option defaults to OpenAI's `omni-moderation-latest`, but you may set it to any supported model. When `gpt-4.1-mini`, `gpt-4.1`, `o3` or `o4-mini` is selected the plugin will use the chat completion API with a system prompt to simply answer whether the message contains profanity.
 You can customize this system prompt via the `chat-prompt` option if you need different wording.
 All categories supported by this model are included in `blocked-categories`:
 

--- a/src/main/java/me/ogulcan/chatmod/service/ModerationService.java
+++ b/src/main/java/me/ogulcan/chatmod/service/ModerationService.java
@@ -47,7 +47,8 @@ public class ModerationService {
         this.model = (model == null || model.isBlank()) ? DEFAULT_MODEL : model;
         this.chatModel = "gpt-4.1-mini".equalsIgnoreCase(this.model) ||
                 "gpt-4.1".equalsIgnoreCase(this.model) ||
-                "o3".equalsIgnoreCase(this.model);
+                "o3".equalsIgnoreCase(this.model) ||
+                "o4-mini".equalsIgnoreCase(this.model);
         this.systemPrompt = (systemPrompt == null || systemPrompt.isBlank()) ? DEFAULT_SYSTEM_PROMPT : systemPrompt;
         this.threshold = threshold;
         this.rateLimit = rateLimit;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,6 +1,6 @@
 openai-key: "REPLACE_ME"
 language: en
-# Set to 'gpt-4.1-mini', 'gpt-4.1' or 'o3' to use the chat model with a profanity check prompt
+# Set to 'gpt-4.1-mini', 'gpt-4.1', 'o3' or 'o4-mini' to use the chat model with a profanity check prompt
 model: omni-moderation-latest
 # Prompt used by the chat model
 chat-prompt: "Bu cümlede küfür veya hakaret varsa sadece var yoksa yok yaz (lan gibi basit argo kelimeleri ve lezyiyen gibi nicknameleri görmezden gel) (kullanıcı küfürü gizlemek için özel karakterler veya sansürler kullanmış olabilir dikkat et):"

--- a/src/test/java/me/ogulcan/chatmod/service/ModerationServiceTest.java
+++ b/src/test/java/me/ogulcan/chatmod/service/ModerationServiceTest.java
@@ -155,6 +155,28 @@ public class ModerationServiceTest {
         assertFalse(r.triggered);
     }
 
+    @Test
+    public void testChatModelTriggeredO4Mini() throws Exception {
+        service = new ModerationService("test", "o4-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT) {
+            @Override
+            protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
+        };
+        server.enqueue(new MockResponse().setBody(chatResponse("var")));
+        ModerationService.Result r = service.moderate("bad").get();
+        assertTrue(r.triggered);
+    }
+
+    @Test
+    public void testChatModelNotTriggeredO4Mini() throws Exception {
+        service = new ModerationService("test", "o4-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT) {
+            @Override
+            protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
+        };
+        server.enqueue(new MockResponse().setBody(chatResponse("yok")));
+        ModerationService.Result r = service.moderate("ok").get();
+        assertFalse(r.triggered);
+    }
+
     private String chatResponse(String text) {
         return new Gson().toJson(Map.of("choices", new Object[]{
                 Map.of("message", Map.of("content", text))


### PR DESCRIPTION
## Summary
- add support for `o4-mini` chat model
- document the new model in README and default config
- test `o4-mini` responses

## Testing
- `gradle wrapper`
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685036af546883309b01a70de3e318ff