### PR TITLE
Fix reasoning model handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Set `countdown-offline` to `false` if you want mute timers to pause while muted 
 Muted players are also blocked from using private messaging commands like `/msg`.
 The `model` option defaults to OpenAI's `omni-moderation-latest`, but you may set it to any supported model. When `gpt-4.1-mini`, `gpt-4.1`, `o3` or `o4-mini` is selected the plugin will use the chat completion API with a system prompt to simply answer whether the message contains profanity.
 You can customize this system prompt via the `chat-prompt` option if you need different wording.
+For reasoning models (`o3`, `o4-mini`), the `thinking-effort` option controls
+the reasoning effort used (`low`, `medium`, or `high`).
 All categories supported by this model are included in `blocked-categories`:
 
 ```

--- a/src/main/java/me/ogulcan/chatmod/Main.java
+++ b/src/main/java/me/ogulcan/chatmod/Main.java
@@ -49,11 +49,12 @@ public class Main extends JavaPlugin {
         int rateLimit = getConfig().getInt("rate-limit", 60);
         String model = getConfig().getString("model", "omni-moderation-latest");
         String prompt = getConfig().getString("chat-prompt", me.ogulcan.chatmod.service.ModerationService.DEFAULT_SYSTEM_PROMPT);
+        String effort = getConfig().getString("thinking-effort", "medium");
         boolean debug = getConfig().getBoolean("debug", false);
         if (debug) {
             getLogger().info("Debug mode enabled");
         }
-        this.moderationService = new ModerationService(apiKey, model, threshold, rateLimit, this.getLogger(), debug, prompt);
+        this.moderationService = new ModerationService(apiKey, model, threshold, rateLimit, this.getLogger(), debug, prompt, effort);
         this.store = new PunishmentStore(new File(getDataFolder(), "data/punishments.json"));
         this.logStore = new LogStore(new File(getDataFolder(), "data/logs.json"));
         getServer().getPluginManager().registerEvents(new ChatListener(this, moderationService, store, logStore), this);
@@ -105,8 +106,9 @@ public class Main extends JavaPlugin {
         int rateLimit = getConfig().getInt("rate-limit", 60);
         String model = getConfig().getString("model", "omni-moderation-latest");
         String prompt = getConfig().getString("chat-prompt", me.ogulcan.chatmod.service.ModerationService.DEFAULT_SYSTEM_PROMPT);
+        String effort = getConfig().getString("thinking-effort", "medium");
         boolean debug = getConfig().getBoolean("debug", false);
-        this.moderationService = new ModerationService(apiKey, model, threshold, rateLimit, this.getLogger(), debug, prompt);
+        this.moderationService = new ModerationService(apiKey, model, threshold, rateLimit, this.getLogger(), debug, prompt, effort);
 
         HandlerList.unregisterAll(this);
         getServer().getPluginManager().registerEvents(new ChatListener(this, moderationService, store, logStore), this);

--- a/src/main/java/me/ogulcan/chatmod/service/ModerationService.java
+++ b/src/main/java/me/ogulcan/chatmod/service/ModerationService.java
@@ -28,6 +28,7 @@ public class ModerationService {
     private final Logger logger;
     private final String model;
     private final boolean chatModel;
+    private final boolean reasoningModel;
     private final boolean enabled;
     private final boolean debug;
     private final String systemPrompt;
@@ -48,6 +49,8 @@ public class ModerationService {
         this.chatModel = "gpt-4.1-mini".equalsIgnoreCase(this.model) ||
                 "gpt-4.1".equalsIgnoreCase(this.model) ||
                 "o3".equalsIgnoreCase(this.model) ||
+                "o4-mini".equalsIgnoreCase(this.model);
+        this.reasoningModel = "o3".equalsIgnoreCase(this.model) ||
                 "o4-mini".equalsIgnoreCase(this.model);
         this.systemPrompt = (systemPrompt == null || systemPrompt.isBlank()) ? DEFAULT_SYSTEM_PROMPT : systemPrompt;
         this.threshold = threshold;
@@ -229,12 +232,22 @@ public class ModerationService {
         final String model = ModerationService.this.model;
         final Message[] messages;
         final double temperature = 0;
-        final int max_tokens = 1;
+        final Integer max_tokens;
+        @SerializedName("max_completion_tokens")
+        final Integer maxCompletionTokens;
+
         ChatPayload(String input) {
             this.messages = new Message[]{
                     new Message("system", systemPrompt),
                     new Message("user", input)
             };
+            if (reasoningModel) {
+                this.max_tokens = null;
+                this.maxCompletionTokens = 1;
+            } else {
+                this.max_tokens = 1;
+                this.maxCompletionTokens = null;
+            }
         }
     }
 

--- a/src/main/java/me/ogulcan/chatmod/service/ModerationService.java
+++ b/src/main/java/me/ogulcan/chatmod/service/ModerationService.java
@@ -29,6 +29,7 @@ public class ModerationService {
     private final String model;
     private final boolean chatModel;
     private final boolean reasoningModel;
+    private final String reasoningEffort;
     private final boolean enabled;
     private final boolean debug;
     private final String systemPrompt;
@@ -43,7 +44,8 @@ public class ModerationService {
         return CHAT_URL;
     }
 
-    public ModerationService(String apiKey, String model, double threshold, int rateLimit, Logger logger, boolean debug, String systemPrompt) {
+    public ModerationService(String apiKey, String model, double threshold, int rateLimit,
+                             Logger logger, boolean debug, String systemPrompt, String reasoningEffort) {
         this.apiKey = apiKey;
         this.model = (model == null || model.isBlank()) ? DEFAULT_MODEL : model;
         this.chatModel = "gpt-4.1-mini".equalsIgnoreCase(this.model) ||
@@ -52,6 +54,7 @@ public class ModerationService {
                 "o4-mini".equalsIgnoreCase(this.model);
         this.reasoningModel = "o3".equalsIgnoreCase(this.model) ||
                 "o4-mini".equalsIgnoreCase(this.model);
+        this.reasoningEffort = reasoningEffort == null ? "medium" : reasoningEffort;
         this.systemPrompt = (systemPrompt == null || systemPrompt.isBlank()) ? DEFAULT_SYSTEM_PROMPT : systemPrompt;
         this.threshold = threshold;
         this.rateLimit = rateLimit;
@@ -235,6 +238,8 @@ public class ModerationService {
         final Integer max_tokens;
         @SerializedName("max_completion_tokens")
         final Integer maxCompletionTokens;
+        @SerializedName("reasoning_effort")
+        final String effort;
 
         ChatPayload(String input) {
             this.messages = new Message[]{
@@ -244,9 +249,11 @@ public class ModerationService {
             if (reasoningModel) {
                 this.max_tokens = null;
                 this.maxCompletionTokens = 1;
+                this.effort = reasoningEffort;
             } else {
                 this.max_tokens = 1;
                 this.maxCompletionTokens = null;
+                this.effort = null;
             }
         }
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,6 +4,7 @@ language: en
 model: omni-moderation-latest
 # Prompt used by the chat model
 chat-prompt: "Sen minecraft sohbet moderatörüsün. Görevin cümlede küfür veya hakaret varsa sadece var yoksa yok yaz (lan gibi basit argo kelimeleri ve lezyiyen gibi nicknameleri ve minecraft sunucularında kullanılan terimleri görmezden gel) (kullanıcı küfürü gizlemek için özel karakterler veya sansürler kullanmış olabilir dikkat et):"
+thinking-effort: medium
 threshold: 0.5
 punishments:
   first: 5

--- a/src/test/java/me/ogulcan/chatmod/service/ModerationServiceTest.java
+++ b/src/test/java/me/ogulcan/chatmod/service/ModerationServiceTest.java
@@ -21,7 +21,7 @@ public class ModerationServiceTest {
     public void setUp() throws IOException {
         server = new MockWebServer();
         server.start();
-        service = new ModerationService("test", "omni-moderation-latest", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT) {
+        service = new ModerationService("test", "omni-moderation-latest", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium") {
             @Override
             protected String getUrl() { return server.url("/v1/moderations").toString(); }
             @Override
@@ -64,7 +64,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testRateLimit() throws Exception {
-        service = new ModerationService("test", "omni-moderation-latest", 0.5, 1, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT) {
+        service = new ModerationService("test", "omni-moderation-latest", 0.5, 1, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium") {
             @Override
             protected String getUrl() { return server.url("/v1/moderations").toString(); }
         };
@@ -84,14 +84,14 @@ public class ModerationServiceTest {
 
     @Test
     public void testDisabledWhenNoApiKey() throws Exception {
-        ModerationService disabled = new ModerationService("", "omni-moderation-latest", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT);
+        ModerationService disabled = new ModerationService("", "omni-moderation-latest", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium");
         ModerationService.Result r = disabled.moderate("whatever").get();
         assertFalse(r.triggered);
     }
 
     @Test
     public void testChatModelTriggered() throws Exception {
-        service = new ModerationService("test", "gpt-4.1-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT) {
+        service = new ModerationService("test", "gpt-4.1-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium") {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -102,7 +102,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelNotTriggered() throws Exception {
-        service = new ModerationService("test", "gpt-4.1-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT) {
+        service = new ModerationService("test", "gpt-4.1-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium") {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -113,7 +113,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelTriggeredGpt41() throws Exception {
-        service = new ModerationService("test", "gpt-4.1", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT) {
+        service = new ModerationService("test", "gpt-4.1", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium") {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -124,7 +124,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelNotTriggeredGpt41() throws Exception {
-        service = new ModerationService("test", "gpt-4.1", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT) {
+        service = new ModerationService("test", "gpt-4.1", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium") {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -135,7 +135,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelTriggeredO3() throws Exception {
-        service = new ModerationService("test", "o3", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT) {
+        service = new ModerationService("test", "o3", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium") {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -146,7 +146,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelNotTriggeredO3() throws Exception {
-        service = new ModerationService("test", "o3", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT) {
+        service = new ModerationService("test", "o3", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium") {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -157,7 +157,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelTriggeredO4Mini() throws Exception {
-        service = new ModerationService("test", "o4-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT) {
+        service = new ModerationService("test", "o4-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium") {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -168,7 +168,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelNotTriggeredO4Mini() throws Exception {
-        service = new ModerationService("test", "o4-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT) {
+        service = new ModerationService("test", "o4-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium") {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };


### PR DESCRIPTION
## Summary
- update `ModerationService` to detect reasoning models
- send `max_completion_tokens` instead of `max_tokens` for reasoning models

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68503cace0508330bae5958ea1d87a0d