### PR TITLE
Fix reasoning model temperature

### DIFF
--- a/src/main/java/me/ogulcan/chatmod/service/ModerationService.java
+++ b/src/main/java/me/ogulcan/chatmod/service/ModerationService.java
@@ -234,7 +234,7 @@ public class ModerationService {
     private class ChatPayload {
         final String model = ModerationService.this.model;
         final Message[] messages;
-        final double temperature = 0;
+        final double temperature = reasoningModel ? 1 : 0;
         final Integer max_tokens;
         @SerializedName("max_completion_tokens")
         final Integer maxCompletionTokens;


### PR DESCRIPTION
## Summary
- use the allowed temperature value when reasoning models are selected

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68505b922184833084709d5e3b6ccccc