### PR TITLE
Fix OpenAI 400 error by increasing chat token limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Muted players are also blocked from using private messaging commands like `/msg`
 The `model` option defaults to OpenAI's `omni-moderation-latest`, but you may set it to any supported model. When `gpt-4.1-mini`, `gpt-4.1`, `o3` or `o4-mini` is selected the plugin will use the chat completion API with a system prompt to simply answer whether the message contains profanity.
 You can customize this system prompt via the `chat-prompt` option if you need different wording.
 For reasoning models (`o3`, `o4-mini`), the `thinking-effort` option controls
-the reasoning effort used (`low`, `medium`, or `high`).
+the reasoning effort used (`low`, `medium`, or `high`). The plugin now allows
+up to **three** tokens in chat model replies to avoid OpenAI errors.
 All categories supported by this model are included in `blocked-categories`:
 
 ```

--- a/src/main/java/me/ogulcan/chatmod/service/ModerationService.java
+++ b/src/main/java/me/ogulcan/chatmod/service/ModerationService.java
@@ -248,10 +248,13 @@ public class ModerationService {
             };
             if (reasoningModel) {
                 this.max_tokens = null;
-                this.maxCompletionTokens = 1;
+                // allow enough tokens for a short "var" or "yok" response
+                this.maxCompletionTokens = 3;
                 this.effort = reasoningEffort;
             } else {
-                this.max_tokens = 1;
+                // gpt-4.1 and similar models may require more than one token
+                // for these short replies
+                this.max_tokens = 3;
                 this.maxCompletionTokens = null;
                 this.effort = null;
             }


### PR DESCRIPTION
## Summary
- bump `max_tokens` and `max_completion_tokens` in `ModerationService`
- document new default of 3 tokens in README

## Testing
- `gradle wrapper --no-daemon --console=plain`
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68505e14e8e08330b79da2dbc4cbcf74