### PR TITLE
Add log size limit to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ paginated view of recent chat logs. Each entry displays the player's head, a
 snippet of the muted message and when it was recorded. These logs are stored in
 `data/logs.json` and persist even if the server runs in offline mode. You can
 remove all entries with the **Clear Logs** button or by running `/cm clearlogs`.
+The `max-log-entries` option in `config.yml` controls how many of these entries
+are kept (default `1000`). When the limit is exceeded, the oldest logs are
+discarded automatically.
 
 Use `/cm reload` to re-read all configuration files. OpenAI options such as
 `openai-key`, `model`, `threshold` and `rate-limit` are applied immediately and

--- a/src/main/java/me/ogulcan/chatmod/storage/LogStore.java
+++ b/src/main/java/me/ogulcan/chatmod/storage/LogStore.java
@@ -32,6 +32,12 @@ public class LogStore {
 
     public synchronized void add(UUID uuid, String name, String message) {
         logs.add(new LogEntry(uuid, name, message, System.currentTimeMillis()));
+        int max = plugin.getConfig().getInt("max-log-entries", 1000);
+        if (max > 0) {
+            while (logs.size() > max) {
+                logs.remove(0);
+            }
+        }
         saveAsync();
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -70,6 +70,7 @@ debug: false
 discord-url: "http://localhost:3000"
 web-port: 8081
 countdown-offline: true
+max-log-entries: 1000
 use-blocked-categories: true
 use-blocked-words: FALSE
 blocked-words:


### PR DESCRIPTION
## Summary
- allow limiting saved log entries
- document `max-log-entries` in README
- add `max-log-entries` default to `config.yml`

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68516ce40f1c8330afaed6d1103edc78