### PR TITLE
Use cached thread pool for HTTP server

### DIFF
--- a/src/main/java/me/ogulcan/chatmod/web/UnmuteServer.java
+++ b/src/main/java/me/ogulcan/chatmod/web/UnmuteServer.java
@@ -24,7 +24,8 @@ public class UnmuteServer {
         this.plugin = plugin;
         server = HttpServer.create(new InetSocketAddress(port), 0);
         server.createContext("/unmute", new UnmuteHandler());
-        server.setExecutor(Executors.newSingleThreadExecutor());
+        // Use a cached thread pool so the server can handle multiple requests concurrently
+        server.setExecutor(Executors.newCachedThreadPool());
         server.start();
     }
 


### PR DESCRIPTION
## Summary
- switch `UnmuteServer` from single-thread executor to cached pool

## Testing
- `gradle wrapper`
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6851713453788330a4d0b11dc0688a9a