### PR TITLE
Reuse single OkHttpClient

### DIFF
--- a/src/main/java/me/ogulcan/chatmod/Main.java
+++ b/src/main/java/me/ogulcan/chatmod/Main.java
@@ -20,6 +20,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
+import okhttp3.OkHttpClient;
 
 public class Main extends JavaPlugin {
     private ModerationService moderationService;
@@ -27,6 +28,7 @@ public class Main extends JavaPlugin {
     private LogStore logStore;
     private DiscordNotifier notifier;
     private UnmuteServer webServer;
+    private final OkHttpClient httpClient = new OkHttpClient();
     private Messages messages;
     private FileConfiguration guiConfig;
     private boolean autoMute = true;
@@ -60,8 +62,9 @@ public class Main extends JavaPlugin {
         if (debug) {
             getLogger().info("Debug mode enabled");
         }
-        this.moderationService = new ModerationService(apiKey, model, threshold, rateLimit, this.getLogger(), debug, prompt, effort);
-        this.notifier = new DiscordNotifier(discordUrl);
+        this.moderationService = new ModerationService(apiKey, model, threshold, rateLimit,
+                this.getLogger(), debug, prompt, effort, httpClient);
+        this.notifier = new DiscordNotifier(discordUrl, httpClient);
         this.store = new PunishmentStore(this, new File(getDataFolder(), "data/punishments.json"));
         this.logStore = new LogStore(this, new File(getDataFolder(), "data/logs.json"));
         if (webPort > 0) {
@@ -125,8 +128,9 @@ public class Main extends JavaPlugin {
         boolean debug = getConfig().getBoolean("debug", false);
         String discordUrl = getConfig().getString("discord-url", "");
         int webPort = getConfig().getInt("web-port", 0);
-        this.moderationService = new ModerationService(apiKey, model, threshold, rateLimit, this.getLogger(), debug, prompt, effort);
-        this.notifier = new DiscordNotifier(discordUrl);
+        this.moderationService = new ModerationService(apiKey, model, threshold, rateLimit,
+                this.getLogger(), debug, prompt, effort, httpClient);
+        this.notifier = new DiscordNotifier(discordUrl, httpClient);
 
         if (webServer != null) {
             webServer.stop();

--- a/src/main/java/me/ogulcan/chatmod/service/DiscordNotifier.java
+++ b/src/main/java/me/ogulcan/chatmod/service/DiscordNotifier.java
@@ -11,11 +11,12 @@ import java.util.Map;
  */
 public class DiscordNotifier {
     private final String url;
-    private final OkHttpClient client = new OkHttpClient();
+    private final OkHttpClient client;
     private final Gson gson = new Gson();
 
-    public DiscordNotifier(String url) {
+    public DiscordNotifier(String url, OkHttpClient client) {
         this.url = url == null ? "" : url.trim();
+        this.client = client;
     }
 
     /**

--- a/src/main/java/me/ogulcan/chatmod/service/ModerationService.java
+++ b/src/main/java/me/ogulcan/chatmod/service/ModerationService.java
@@ -20,7 +20,7 @@ public class ModerationService {
     private static final String DEFAULT_MODEL = "omni-moderation-latest";
     public static final String DEFAULT_SYSTEM_PROMPT =
             "Sen minecraft sohbet moderatörüsün. Görevin Türkçe cümlede küfür veya hakaret varsa sadece var yoksa yok yaz (lan, altıma sıçtım gibi basit argo kelimeleri ve lezyiyen gibi nicknameleri ve minecraft sunucularında kullanılan terimleri görmezden gel sadece kullanıcıların birbirlerine doğrudan küfür ve hakaret emlerine izin vermeyeceksin) (kullanıcı küfürü gizlemek için özel karakterler veya sansürler kullanmış olabilir dikkat et):";
-    private final OkHttpClient client = new OkHttpClient();
+    private final OkHttpClient client;
     private final Gson gson = new Gson();
     private final String apiKey;
     private final double threshold;
@@ -45,7 +45,9 @@ public class ModerationService {
     }
 
     public ModerationService(String apiKey, String model, double threshold, int rateLimit,
-                             Logger logger, boolean debug, String systemPrompt, String reasoningEffort) {
+                             Logger logger, boolean debug, String systemPrompt,
+                             String reasoningEffort, OkHttpClient client) {
+        this.client = client;
         this.apiKey = apiKey;
         this.model = (model == null || model.isBlank()) ? DEFAULT_MODEL : model;
         this.chatModel = "gpt-4.1-mini".equalsIgnoreCase(this.model) ||

--- a/src/test/java/me/ogulcan/chatmod/service/ModerationServiceTest.java
+++ b/src/test/java/me/ogulcan/chatmod/service/ModerationServiceTest.java
@@ -21,7 +21,9 @@ public class ModerationServiceTest {
     public void setUp() throws IOException {
         server = new MockWebServer();
         server.start();
-        service = new ModerationService("test", "omni-moderation-latest", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium") {
+        service = new ModerationService("test", "omni-moderation-latest", 0.5, 60,
+                java.util.logging.Logger.getAnonymousLogger(), false,
+                ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", new okhttp3.OkHttpClient()) {
             @Override
             protected String getUrl() { return server.url("/v1/moderations").toString(); }
             @Override
@@ -64,7 +66,9 @@ public class ModerationServiceTest {
 
     @Test
     public void testRateLimit() throws Exception {
-        service = new ModerationService("test", "omni-moderation-latest", 0.5, 1, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium") {
+        service = new ModerationService("test", "omni-moderation-latest", 0.5, 1,
+                java.util.logging.Logger.getAnonymousLogger(), false,
+                ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", new okhttp3.OkHttpClient()) {
             @Override
             protected String getUrl() { return server.url("/v1/moderations").toString(); }
         };
@@ -84,14 +88,18 @@ public class ModerationServiceTest {
 
     @Test
     public void testDisabledWhenNoApiKey() throws Exception {
-        ModerationService disabled = new ModerationService("", "omni-moderation-latest", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium");
+        ModerationService disabled = new ModerationService("", "omni-moderation-latest", 0.5, 60,
+                java.util.logging.Logger.getAnonymousLogger(), false,
+                ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", new okhttp3.OkHttpClient());
         ModerationService.Result r = disabled.moderate("whatever").get();
         assertFalse(r.triggered);
     }
 
     @Test
     public void testChatModelTriggered() throws Exception {
-        service = new ModerationService("test", "gpt-4.1-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium") {
+        service = new ModerationService("test", "gpt-4.1-mini", 0.5, 60,
+                java.util.logging.Logger.getAnonymousLogger(), false,
+                ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", new okhttp3.OkHttpClient()) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -102,7 +110,9 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelNotTriggered() throws Exception {
-        service = new ModerationService("test", "gpt-4.1-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium") {
+        service = new ModerationService("test", "gpt-4.1-mini", 0.5, 60,
+                java.util.logging.Logger.getAnonymousLogger(), false,
+                ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", new okhttp3.OkHttpClient()) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -113,7 +123,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelTriggeredGpt41() throws Exception {
-        service = new ModerationService("test", "gpt-4.1", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium") {
+        service = new ModerationService("test", "gpt-4.1", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", new okhttp3.OkHttpClient()) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -124,7 +134,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelNotTriggeredGpt41() throws Exception {
-        service = new ModerationService("test", "gpt-4.1", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium") {
+        service = new ModerationService("test", "gpt-4.1", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", new okhttp3.OkHttpClient()) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -135,7 +145,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelTriggeredO3() throws Exception {
-        service = new ModerationService("test", "o3", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium") {
+        service = new ModerationService("test", "o3", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", new okhttp3.OkHttpClient()) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -146,7 +156,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelNotTriggeredO3() throws Exception {
-        service = new ModerationService("test", "o3", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium") {
+        service = new ModerationService("test", "o3", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", new okhttp3.OkHttpClient()) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -157,7 +167,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelTriggeredO4Mini() throws Exception {
-        service = new ModerationService("test", "o4-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium") {
+        service = new ModerationService("test", "o4-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", new okhttp3.OkHttpClient()) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -168,7 +178,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelNotTriggeredO4Mini() throws Exception {
-        service = new ModerationService("test", "o4-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium") {
+        service = new ModerationService("test", "o4-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", new okhttp3.OkHttpClient()) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };


### PR DESCRIPTION
## Summary
- reuse an OkHttpClient instance across services
- let Main pass the shared client to ModerationService and DiscordNotifier
- update unit tests for the new constructors

## Testing
- `gradle wrapper`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6851726c89dc8330b7e783e490415ff5