### PR TITLE
Add dirty flags with scheduled saves

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     testImplementation("org.mockito:mockito-core:5.7.0")
+    testImplementation("com.github.seeseemelk:MockBukkit-v1.20:3.16.0")
 }
 
 tasks.test {

--- a/src/main/java/me/ogulcan/chatmod/Main.java
+++ b/src/main/java/me/ogulcan/chatmod/Main.java
@@ -153,6 +153,12 @@ public class Main extends JavaPlugin {
 
     @Override
     public void onDisable() {
+        if (store != null) {
+            store.close();
+        }
+        if (logStore != null) {
+            logStore.close();
+        }
         if (webServer != null) {
             webServer.stop();
             webServer = null;

--- a/src/test/java/me/ogulcan/chatmod/storage/LogStoreTest.java
+++ b/src/test/java/me/ogulcan/chatmod/storage/LogStoreTest.java
@@ -1,0 +1,49 @@
+package me.ogulcan.chatmod.storage;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.MockPlugin;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LogStoreTest {
+    private MockPlugin plugin;
+    private File tempDir;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        MockBukkit.mock();
+        plugin = MockBukkit.createMockPlugin();
+        tempDir = Files.createTempDirectory("logs").toFile();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        MockBukkit.unmock();
+        if (tempDir != null) {
+            for (File f : tempDir.listFiles()) {
+                f.delete();
+            }
+            tempDir.delete();
+        }
+    }
+
+    @Test
+    public void testDeferredSave() throws Exception {
+        File file = new File(tempDir, "logs.json");
+        LogStore store = new LogStore(plugin, file);
+        store.add(UUID.randomUUID(), "Bob", "hello");
+        assertFalse(file.exists() && file.length() > 0);
+        MockBukkit.getMock().getScheduler().performTicks(80L);
+        MockBukkit.getMock().getScheduler().waitAsyncTasksFinished();
+        assertFalse(file.exists() && file.length() > 0);
+        store.close();
+        assertTrue(file.exists() && file.length() > 0);
+    }
+}

--- a/src/test/java/me/ogulcan/chatmod/storage/PunishmentStoreTest.java
+++ b/src/test/java/me/ogulcan/chatmod/storage/PunishmentStoreTest.java
@@ -1,0 +1,49 @@
+package me.ogulcan.chatmod.storage;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.MockPlugin;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PunishmentStoreTest {
+    private MockPlugin plugin;
+    private File tempDir;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        MockBukkit.mock();
+        plugin = MockBukkit.createMockPlugin();
+        tempDir = Files.createTempDirectory("punish").toFile();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        MockBukkit.unmock();
+        if (tempDir != null) {
+            for (File f : tempDir.listFiles()) {
+                f.delete();
+            }
+            tempDir.delete();
+        }
+    }
+
+    @Test
+    public void testDeferredSave() {
+        File file = new File(tempDir, "punishments.json");
+        PunishmentStore store = new PunishmentStore(plugin, file);
+        store.mute(UUID.randomUUID(), 5);
+        assertFalse(file.exists() && file.length() > 0);
+        MockBukkit.getMock().getScheduler().performTicks(80L);
+        MockBukkit.getMock().getScheduler().waitAsyncTasksFinished();
+        assertFalse(file.exists() && file.length() > 0);
+        store.close();
+        assertTrue(file.exists() && file.length() > 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add MockBukkit test dependency
- add dirty flag with periodic save task to `LogStore` and `PunishmentStore`
- flush stores on plugin disable
- add new unit tests for deferred saving

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685174ea633483308d5eba22deb2fe4c