### PR TITLE
Refactor save tasks to single async thread

### DIFF
--- a/src/main/java/me/ogulcan/chatmod/storage/LogStore.java
+++ b/src/main/java/me/ogulcan/chatmod/storage/LogStore.java
@@ -30,6 +30,8 @@ public class LogStore {
         this.file = file;
         if (!file.getParentFile().exists()) file.getParentFile().mkdirs();
         load();
+        // All file writes are performed by this dedicated async task running on
+        // Bukkit's single async thread.
         this.task = new org.bukkit.scheduler.BukkitRunnable() {
             @Override
             public void run() {
@@ -82,9 +84,12 @@ public class LogStore {
         }
     }
 
-    /** Run {@code save()} asynchronously using the Bukkit scheduler. */
+    /**
+     * Mark the store as dirty so the periodic async task will persist changes.
+     * All actual file writes occur on that dedicated thread.
+     */
     public void saveAsync() {
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, this::save);
+        markDirty();
     }
 
     private synchronized void markDirty() {

--- a/src/main/java/me/ogulcan/chatmod/storage/PunishmentStore.java
+++ b/src/main/java/me/ogulcan/chatmod/storage/PunishmentStore.java
@@ -26,6 +26,8 @@ public class PunishmentStore {
         this.file = file;
         if (!file.getParentFile().exists()) file.getParentFile().mkdirs();
         load();
+        // All file writes are performed by this dedicated async task running on
+        // Bukkit's single async thread.
         this.task = new org.bukkit.scheduler.BukkitRunnable() {
             @Override
             public void run() {
@@ -136,9 +138,12 @@ public class PunishmentStore {
         }
     }
 
-    /** Run {@code save()} asynchronously using the Bukkit scheduler. */
+    /**
+     * Mark the store as dirty so the periodic async task will persist changes.
+     * All actual file writes occur on that dedicated thread.
+     */
     public void saveAsync() {
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, this::save);
+        markDirty();
     }
 
     private synchronized void markDirty() {


### PR DESCRIPTION
## Summary
- run periodic store saves on the async scheduler thread
- mark saves dirty instead of scheduling an async task
- document that saves happen on the periodic task

## Testing
- `gradle wrapper`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68517887b37883308de4c14b7d3ea64a