### PR TITLE
Make unmute server thread pool configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Set `language` to `en` or `tr` to change plugin messages. The selected language 
 Enable `debug: true` in `config.yml` to log moderation responses and the selected moderation model for troubleshooting.
 Set `countdown-offline` to `false` if you want mute timers to pause while muted players are offline.
 Muted players are also blocked from using private messaging commands like `/msg`.
+The `unmute-threads` option controls how many threads the built-in web server uses to
+process `/unmute` requests (default `10`).
 The `model` option defaults to OpenAI's `omni-moderation-latest`, but you may set it to any supported model. When `gpt-4.1-mini`, `gpt-4.1`, `o3` or `o4-mini` is selected the plugin will use the chat completion API with a system prompt to simply answer whether the message contains profanity.
 You can customize this system prompt via the `chat-prompt` option if you need different wording.
 For reasoning models (`o3`, `o4-mini`), the `thinking-effort` option controls

--- a/src/main/java/me/ogulcan/chatmod/Main.java
+++ b/src/main/java/me/ogulcan/chatmod/Main.java
@@ -59,6 +59,7 @@ public class Main extends JavaPlugin {
         boolean debug = getConfig().getBoolean("debug", false);
         String discordUrl = getConfig().getString("discord-url", "");
         int webPort = getConfig().getInt("web-port", 0);
+        int unmuteThreads = getConfig().getInt("unmute-threads", 10);
         if (debug) {
             getLogger().info("Debug mode enabled");
         }
@@ -69,7 +70,7 @@ public class Main extends JavaPlugin {
         this.logStore = new LogStore(this, new File(getDataFolder(), "data/logs.json"));
         if (webPort > 0) {
             try {
-                this.webServer = new UnmuteServer(this, webPort);
+                this.webServer = new UnmuteServer(this, webPort, unmuteThreads);
                 getLogger().info("Web server running on port " + webPort);
             } catch (Exception e) {
                 getLogger().warning("Failed to start web server: " + e.getMessage());
@@ -128,6 +129,7 @@ public class Main extends JavaPlugin {
         boolean debug = getConfig().getBoolean("debug", false);
         String discordUrl = getConfig().getString("discord-url", "");
         int webPort = getConfig().getInt("web-port", 0);
+        int unmuteThreads = getConfig().getInt("unmute-threads", 10);
         this.moderationService = new ModerationService(apiKey, model, threshold, rateLimit,
                 this.getLogger(), debug, prompt, effort, httpClient);
         this.notifier = new DiscordNotifier(discordUrl, httpClient);
@@ -138,7 +140,7 @@ public class Main extends JavaPlugin {
         }
         if (webPort > 0) {
             try {
-                webServer = new UnmuteServer(this, webPort);
+                webServer = new UnmuteServer(this, webPort, unmuteThreads);
                 getLogger().info("Web server running on port " + webPort);
             } catch (Exception e) {
                 getLogger().warning("Failed to start web server: " + e.getMessage());

--- a/src/main/java/me/ogulcan/chatmod/web/UnmuteServer.java
+++ b/src/main/java/me/ogulcan/chatmod/web/UnmuteServer.java
@@ -20,12 +20,12 @@ public class UnmuteServer {
     private final Gson gson = new Gson();
     private final Main plugin;
 
-    public UnmuteServer(Main plugin, int port) throws IOException {
+    public UnmuteServer(Main plugin, int port, int threads) throws IOException {
         this.plugin = plugin;
         server = HttpServer.create(new InetSocketAddress(port), 0);
         server.createContext("/unmute", new UnmuteHandler());
-        // Use a cached thread pool so the server can handle multiple requests concurrently
-        server.setExecutor(Executors.newCachedThreadPool());
+        // Use a fixed thread pool to handle concurrent requests
+        server.setExecutor(Executors.newFixedThreadPool(threads));
         server.start();
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -69,6 +69,7 @@ rate-limit: 250
 debug: false
 discord-url: "http://localhost:3000"
 web-port: 8081
+unmute-threads: 10
 countdown-offline: true
 max-log-entries: 1000
 use-blocked-categories: true


### PR DESCRIPTION
## Summary
- add `unmute-threads` option to config with default 10
- allow `UnmuteServer` to use a fixed thread pool
- read the pool size in `Main` and pass it to `UnmuteServer`
- document the new config option in the README

## Testing
- `gradle wrapper`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6851b0d67b2c8330ab22bdb1c068d69e