### PR TITLE
Optimize blocked word lookup

### DIFF
--- a/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
+++ b/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
@@ -27,7 +27,7 @@ public class ChatListener implements Listener {
     private final DiscordNotifier notifier;
     private final List<String> categories;
     private final List<String> words;
-    private final List<String> normalizedWords;
+    private final java.util.Set<String> normalizedWords;
     private final boolean useBlockedWords;
     private final boolean useBlockedCategories;
     private final Map<String, Boolean> categoryEnabled;
@@ -43,7 +43,7 @@ public class ChatListener implements Listener {
         this.words = plugin.getConfig().getStringList("blocked-words");
         this.normalizedWords = this.words.stream()
                 .map(WordFilter::normalize)
-                .toList();
+                .collect(java.util.stream.Collectors.toSet());
         this.useBlockedWords = plugin.getConfig().getBoolean("use-blocked-words", true);
         this.useBlockedCategories = plugin.getConfig().getBoolean("use-blocked-categories", true);
         this.categoryEnabled = new HashMap<>();

--- a/src/test/java/me/ogulcan/chatmod/service/WordFilterTest.java
+++ b/src/test/java/me/ogulcan/chatmod/service/WordFilterTest.java
@@ -2,6 +2,7 @@ package me.ogulcan.chatmod.service;
 
 import org.junit.jupiter.api.Test;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -38,17 +39,17 @@ public class WordFilterTest {
 
     @Test
     public void testNormalizedWordList() {
-        List<String> words = List.of("orospu", "piç").stream()
+        Set<String> words = List.of("orospu", "piç").stream()
                 .map(WordFilter::normalize)
-                .toList();
+                .collect(java.util.stream.Collectors.toSet());
         assertTrue(WordFilter.containsBlockedWord("Sen bir orospu çocuğusun", words, true));
     }
 
     @Test
     public void testNormalizedWordListClean() {
-        List<String> words = List.of("orospu", "piç").stream()
+        Set<String> words = List.of("orospu", "piç").stream()
                 .map(WordFilter::normalize)
-                .toList();
+                .collect(java.util.stream.Collectors.toSet());
         assertFalse(WordFilter.containsBlockedWord("Merhaba nasılsın", words, true));
     }
 


### PR DESCRIPTION
## Summary
- switch normalized blocked word list to a `Set`
- check tokens against the set for speed
- create the normalized set once in `ChatListener`
- update tests for the new set-based API

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6851ba91cf3c833082915ec08f49a10b