### PR TITLE
Add moderation caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Set `countdown-offline` to `false` if you want mute timers to pause while muted 
 Muted players are also blocked from using private messaging commands like `/msg`.
 The `unmute-threads` option controls how many threads the built-in web server uses to
 process `/unmute` requests (default `10`).
+The `moderation-cache-minutes` option controls how long moderation results are cached to avoid duplicate API calls (default `5`).
 The `model` option defaults to OpenAI's `omni-moderation-latest`, but you may set it to any supported model. When `gpt-4.1-mini`, `gpt-4.1`, `o3` or `o4-mini` is selected the plugin will use the chat completion API with a system prompt to simply answer whether the message contains profanity.
 You can customize this system prompt via the `chat-prompt` option if you need different wording.
 For reasoning models (`o3`, `o4-mini`), the `thinking-effort` option controls

--- a/src/main/java/me/ogulcan/chatmod/Main.java
+++ b/src/main/java/me/ogulcan/chatmod/Main.java
@@ -56,6 +56,7 @@ public class Main extends JavaPlugin {
         String model = getConfig().getString("model", "omni-moderation-latest");
         String prompt = getConfig().getString("chat-prompt", me.ogulcan.chatmod.service.ModerationService.DEFAULT_SYSTEM_PROMPT);
         String effort = getConfig().getString("thinking-effort", "medium");
+        long cacheMinutes = getConfig().getLong("moderation-cache-minutes", 5);
         boolean debug = getConfig().getBoolean("debug", false);
         String discordUrl = getConfig().getString("discord-url", "");
         int webPort = getConfig().getInt("web-port", 0);
@@ -64,7 +65,7 @@ public class Main extends JavaPlugin {
             getLogger().info("Debug mode enabled");
         }
         this.moderationService = new ModerationService(apiKey, model, threshold, rateLimit,
-                this.getLogger(), debug, prompt, effort, httpClient);
+                this.getLogger(), debug, prompt, effort, cacheMinutes, httpClient);
         this.notifier = new DiscordNotifier(discordUrl, httpClient);
         this.store = new PunishmentStore(this, new File(getDataFolder(), "data/punishments.json"));
         this.logStore = new LogStore(this, new File(getDataFolder(), "data/logs.json"));
@@ -130,8 +131,9 @@ public class Main extends JavaPlugin {
         String discordUrl = getConfig().getString("discord-url", "");
         int webPort = getConfig().getInt("web-port", 0);
         int unmuteThreads = getConfig().getInt("unmute-threads", 10);
+        long cacheMinutes = getConfig().getLong("moderation-cache-minutes", 5);
         this.moderationService = new ModerationService(apiKey, model, threshold, rateLimit,
-                this.getLogger(), debug, prompt, effort, httpClient);
+                this.getLogger(), debug, prompt, effort, cacheMinutes, httpClient);
         this.notifier = new DiscordNotifier(discordUrl, httpClient);
 
         if (webServer != null) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -66,6 +66,7 @@ category-settings:
     enabled: false
     ratio: 0.5
 rate-limit: 250
+moderation-cache-minutes: 5
 debug: false
 discord-url: "http://localhost:3000"
 web-port: 8081

--- a/src/test/java/me/ogulcan/chatmod/service/ModerationServiceTest.java
+++ b/src/test/java/me/ogulcan/chatmod/service/ModerationServiceTest.java
@@ -23,7 +23,8 @@ public class ModerationServiceTest {
         server.start();
         service = new ModerationService("test", "omni-moderation-latest", 0.5, 60,
                 java.util.logging.Logger.getAnonymousLogger(), false,
-                ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", new okhttp3.OkHttpClient()) {
+                ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10,
+                new okhttp3.OkHttpClient()) {
             @Override
             protected String getUrl() { return server.url("/v1/moderations").toString(); }
             @Override
@@ -68,7 +69,8 @@ public class ModerationServiceTest {
     public void testRateLimit() throws Exception {
         service = new ModerationService("test", "omni-moderation-latest", 0.5, 1,
                 java.util.logging.Logger.getAnonymousLogger(), false,
-                ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", new okhttp3.OkHttpClient()) {
+                ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10,
+                new okhttp3.OkHttpClient()) {
             @Override
             protected String getUrl() { return server.url("/v1/moderations").toString(); }
         };
@@ -90,7 +92,8 @@ public class ModerationServiceTest {
     public void testDisabledWhenNoApiKey() throws Exception {
         ModerationService disabled = new ModerationService("", "omni-moderation-latest", 0.5, 60,
                 java.util.logging.Logger.getAnonymousLogger(), false,
-                ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", new okhttp3.OkHttpClient());
+                ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10,
+                new okhttp3.OkHttpClient());
         ModerationService.Result r = disabled.moderate("whatever").get();
         assertFalse(r.triggered);
     }
@@ -99,7 +102,8 @@ public class ModerationServiceTest {
     public void testChatModelTriggered() throws Exception {
         service = new ModerationService("test", "gpt-4.1-mini", 0.5, 60,
                 java.util.logging.Logger.getAnonymousLogger(), false,
-                ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", new okhttp3.OkHttpClient()) {
+                ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10,
+                new okhttp3.OkHttpClient()) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -112,7 +116,8 @@ public class ModerationServiceTest {
     public void testChatModelNotTriggered() throws Exception {
         service = new ModerationService("test", "gpt-4.1-mini", 0.5, 60,
                 java.util.logging.Logger.getAnonymousLogger(), false,
-                ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", new okhttp3.OkHttpClient()) {
+                ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10,
+                new okhttp3.OkHttpClient()) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -123,7 +128,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelTriggeredGpt41() throws Exception {
-        service = new ModerationService("test", "gpt-4.1", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", new okhttp3.OkHttpClient()) {
+        service = new ModerationService("test", "gpt-4.1", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10, new okhttp3.OkHttpClient()) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -134,7 +139,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelNotTriggeredGpt41() throws Exception {
-        service = new ModerationService("test", "gpt-4.1", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", new okhttp3.OkHttpClient()) {
+        service = new ModerationService("test", "gpt-4.1", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10, new okhttp3.OkHttpClient()) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -145,7 +150,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelTriggeredO3() throws Exception {
-        service = new ModerationService("test", "o3", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", new okhttp3.OkHttpClient()) {
+        service = new ModerationService("test", "o3", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10, new okhttp3.OkHttpClient()) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -156,7 +161,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelNotTriggeredO3() throws Exception {
-        service = new ModerationService("test", "o3", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", new okhttp3.OkHttpClient()) {
+        service = new ModerationService("test", "o3", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10, new okhttp3.OkHttpClient()) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -167,7 +172,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelTriggeredO4Mini() throws Exception {
-        service = new ModerationService("test", "o4-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", new okhttp3.OkHttpClient()) {
+        service = new ModerationService("test", "o4-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10, new okhttp3.OkHttpClient()) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -178,13 +183,25 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelNotTriggeredO4Mini() throws Exception {
-        service = new ModerationService("test", "o4-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", new okhttp3.OkHttpClient()) {
+        service = new ModerationService("test", "o4-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10, new okhttp3.OkHttpClient()) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
         server.enqueue(new MockResponse().setBody(chatResponse("yok")));
         ModerationService.Result r = service.moderate("ok").get();
         assertFalse(r.triggered);
+    }
+
+    @Test
+    public void testCacheBypassesApi() throws Exception {
+        server.enqueue(new MockResponse().setBody(response(false, false, 0.1)));
+        ModerationService.Result r1 = service.moderate("hello").get();
+        assertFalse(r1.triggered);
+        assertEquals(1, server.getRequestCount());
+
+        ModerationService.Result r2 = service.moderate("Hello").get();
+        assertFalse(r2.triggered);
+        assertEquals(1, server.getRequestCount());
     }
 
     private String chatResponse(String text) {


### PR DESCRIPTION
## Summary
- add TTL cache to `ModerationService`
- support new `moderation-cache-minutes` option in config
- document cache option in README
- test that cached calls avoid API hits

## Testing
- `gradle wrapper`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6851bc15f658833097bbdcaa66d97d9e