### PR TITLE
Add configurable save interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ remove all entries with the **Clear Logs** button or by running `/cm clearlogs`.
 The `max-log-entries` option in `config.yml` controls how many of these entries
 are kept (default `1000`). When the limit is exceeded, the oldest logs are
 discarded automatically.
+The `save-interval-ticks` option determines how often punishment and log files
+are persisted (default `100` ticks).
 
 Use `/cm reload` to re-read all configuration files. OpenAI options such as
 `openai-key`, `model`, `threshold` and `rate-limit` are applied immediately and

--- a/src/main/java/me/ogulcan/chatmod/storage/LogStore.java
+++ b/src/main/java/me/ogulcan/chatmod/storage/LogStore.java
@@ -32,6 +32,7 @@ public class LogStore {
         load();
         // All file writes are performed by this dedicated async task running on
         // Bukkit's single async thread.
+        long interval = plugin.getConfig().getLong("save-interval-ticks", 100L);
         this.task = new org.bukkit.scheduler.BukkitRunnable() {
             @Override
             public void run() {
@@ -42,7 +43,7 @@ public class LogStore {
                     }
                 }
             }
-        }.runTaskTimerAsynchronously(plugin, 100L, 100L);
+        }.runTaskTimerAsynchronously(plugin, interval, interval);
     }
 
     public synchronized void add(UUID uuid, String name, String message) {

--- a/src/main/java/me/ogulcan/chatmod/storage/PunishmentStore.java
+++ b/src/main/java/me/ogulcan/chatmod/storage/PunishmentStore.java
@@ -28,6 +28,7 @@ public class PunishmentStore {
         load();
         // All file writes are performed by this dedicated async task running on
         // Bukkit's single async thread.
+        long interval = plugin.getConfig().getLong("save-interval-ticks", 100L);
         this.task = new org.bukkit.scheduler.BukkitRunnable() {
             @Override
             public void run() {
@@ -38,7 +39,7 @@ public class PunishmentStore {
                     }
                 }
             }
-        }.runTaskTimerAsynchronously(plugin, 100L, 100L);
+        }.runTaskTimerAsynchronously(plugin, interval, interval);
     }
 
     public synchronized void mute(UUID uuid, long durationMinutes) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -73,6 +73,7 @@ web-port: 8081
 unmute-threads: 10
 countdown-offline: true
 max-log-entries: 1000
+save-interval-ticks: 100
 use-blocked-categories: true
 use-blocked-words: FALSE
 blocked-words:

--- a/src/test/java/me/ogulcan/chatmod/storage/LogStoreTest.java
+++ b/src/test/java/me/ogulcan/chatmod/storage/LogStoreTest.java
@@ -46,4 +46,16 @@ public class LogStoreTest {
         store.close();
         assertTrue(file.exists() && file.length() > 0);
     }
+
+    @Test
+    public void testCustomInterval() throws Exception {
+        File file = new File(tempDir, "logs_custom.json");
+        plugin.getConfig().set("save-interval-ticks", 20);
+        LogStore store = new LogStore(plugin, file);
+        store.add(UUID.randomUUID(), "Alice", "hi");
+        MockBukkit.getMock().getScheduler().performTicks(25L);
+        MockBukkit.getMock().getScheduler().waitAsyncTasksFinished();
+        assertTrue(file.exists() && file.length() > 0);
+        store.close();
+    }
 }

--- a/src/test/java/me/ogulcan/chatmod/storage/PunishmentStoreTest.java
+++ b/src/test/java/me/ogulcan/chatmod/storage/PunishmentStoreTest.java
@@ -46,4 +46,16 @@ public class PunishmentStoreTest {
         store.close();
         assertTrue(file.exists() && file.length() > 0);
     }
+
+    @Test
+    public void testCustomInterval() throws Exception {
+        File file = new File(tempDir, "punish_custom.json");
+        plugin.getConfig().set("save-interval-ticks", 20);
+        PunishmentStore store = new PunishmentStore(plugin, file);
+        store.mute(UUID.randomUUID(), 5);
+        MockBukkit.getMock().getScheduler().performTicks(25L);
+        MockBukkit.getMock().getScheduler().waitAsyncTasksFinished();
+        assertTrue(file.exists() && file.length() > 0);
+        store.close();
+    }
 }


### PR DESCRIPTION
## Summary
- add `save-interval-ticks` to `config.yml`
- allow `LogStore` and `PunishmentStore` to read the interval from config
- test custom intervals for both stores
- document the new option in README

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6851bfc36d188330a454eddf85706cfb