### PR TITLE
Add configurable HTTP client settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Muted players are also blocked from using private messaging commands like `/msg`
 The `unmute-threads` option controls how many threads the built-in web server uses to
 process `/unmute` requests (default `10`).
 The `moderation-cache-minutes` option controls how long moderation results are cached to avoid duplicate API calls (default `5`).
+`http-connect-timeout` and `http-read-timeout` configure OkHttp timeouts in seconds (default `10`).
+`http-max-requests` and `http-max-requests-per-host` adjust the HTTP dispatcher limits (default `100`).
 The `model` option defaults to OpenAI's `omni-moderation-latest`, but you may set it to any supported model. When `gpt-4.1-mini`, `gpt-4.1`, `o3` or `o4-mini` is selected the plugin will use the chat completion API with a system prompt to simply answer whether the message contains profanity.
 You can customize this system prompt via the `chat-prompt` option if you need different wording.
 For reasoning models (`o3`, `o4-mini`), the `thinking-effort` option controls

--- a/src/main/java/me/ogulcan/chatmod/Main.java
+++ b/src/main/java/me/ogulcan/chatmod/Main.java
@@ -21,6 +21,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
 import okhttp3.OkHttpClient;
+import okhttp3.Dispatcher;
 
 public class Main extends JavaPlugin {
     private ModerationService moderationService;
@@ -28,7 +29,7 @@ public class Main extends JavaPlugin {
     private LogStore logStore;
     private DiscordNotifier notifier;
     private UnmuteServer webServer;
-    private final OkHttpClient httpClient = new OkHttpClient();
+    private OkHttpClient httpClient;
     private Messages messages;
     private FileConfiguration guiConfig;
     private boolean autoMute = true;
@@ -58,6 +59,18 @@ public class Main extends JavaPlugin {
         String effort = getConfig().getString("thinking-effort", "medium");
         long cacheMinutes = getConfig().getLong("moderation-cache-minutes", 5);
         boolean debug = getConfig().getBoolean("debug", false);
+        int connectTimeout = getConfig().getInt("http-connect-timeout", 10);
+        int readTimeout = getConfig().getInt("http-read-timeout", 10);
+        int maxRequests = getConfig().getInt("http-max-requests", 100);
+        int maxRequestsPerHost = getConfig().getInt("http-max-requests-per-host", 100);
+        Dispatcher dispatcher = new Dispatcher();
+        dispatcher.setMaxRequests(maxRequests);
+        dispatcher.setMaxRequestsPerHost(maxRequestsPerHost);
+        this.httpClient = new OkHttpClient.Builder()
+                .connectTimeout(connectTimeout, java.util.concurrent.TimeUnit.SECONDS)
+                .readTimeout(readTimeout, java.util.concurrent.TimeUnit.SECONDS)
+                .dispatcher(dispatcher)
+                .build();
         String discordUrl = getConfig().getString("discord-url", "");
         int webPort = getConfig().getInt("web-port", 0);
         int unmuteThreads = getConfig().getInt("unmute-threads", 10);
@@ -128,6 +141,18 @@ public class Main extends JavaPlugin {
         String prompt = getConfig().getString("chat-prompt", me.ogulcan.chatmod.service.ModerationService.DEFAULT_SYSTEM_PROMPT);
         String effort = getConfig().getString("thinking-effort", "medium");
         boolean debug = getConfig().getBoolean("debug", false);
+        int connectTimeout = getConfig().getInt("http-connect-timeout", 10);
+        int readTimeout = getConfig().getInt("http-read-timeout", 10);
+        int maxRequests = getConfig().getInt("http-max-requests", 100);
+        int maxRequestsPerHost = getConfig().getInt("http-max-requests-per-host", 100);
+        Dispatcher dispatcher = new Dispatcher();
+        dispatcher.setMaxRequests(maxRequests);
+        dispatcher.setMaxRequestsPerHost(maxRequestsPerHost);
+        this.httpClient = new OkHttpClient.Builder()
+                .connectTimeout(connectTimeout, java.util.concurrent.TimeUnit.SECONDS)
+                .readTimeout(readTimeout, java.util.concurrent.TimeUnit.SECONDS)
+                .dispatcher(dispatcher)
+                .build();
         String discordUrl = getConfig().getString("discord-url", "");
         int webPort = getConfig().getInt("web-port", 0);
         int unmuteThreads = getConfig().getInt("unmute-threads", 10);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -71,6 +71,10 @@ debug: false
 discord-url: "http://localhost:3000"
 web-port: 8081
 unmute-threads: 10
+http-connect-timeout: 10
+http-read-timeout: 10
+http-max-requests: 100
+http-max-requests-per-host: 100
 countdown-offline: true
 max-log-entries: 1000
 save-interval-ticks: 100

--- a/src/test/java/me/ogulcan/chatmod/service/ModerationServiceTest.java
+++ b/src/test/java/me/ogulcan/chatmod/service/ModerationServiceTest.java
@@ -24,7 +24,7 @@ public class ModerationServiceTest {
         service = new ModerationService("test", "omni-moderation-latest", 0.5, 60,
                 java.util.logging.Logger.getAnonymousLogger(), false,
                 ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10,
-                new okhttp3.OkHttpClient()) {
+                new okhttp3.OkHttpClient.Builder().build()) {
             @Override
             protected String getUrl() { return server.url("/v1/moderations").toString(); }
             @Override
@@ -70,7 +70,7 @@ public class ModerationServiceTest {
         service = new ModerationService("test", "omni-moderation-latest", 0.5, 1,
                 java.util.logging.Logger.getAnonymousLogger(), false,
                 ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10,
-                new okhttp3.OkHttpClient()) {
+                new okhttp3.OkHttpClient.Builder().build()) {
             @Override
             protected String getUrl() { return server.url("/v1/moderations").toString(); }
         };
@@ -93,7 +93,7 @@ public class ModerationServiceTest {
         ModerationService disabled = new ModerationService("", "omni-moderation-latest", 0.5, 60,
                 java.util.logging.Logger.getAnonymousLogger(), false,
                 ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10,
-                new okhttp3.OkHttpClient());
+                new okhttp3.OkHttpClient.Builder().build());
         ModerationService.Result r = disabled.moderate("whatever").get();
         assertFalse(r.triggered);
     }
@@ -103,7 +103,7 @@ public class ModerationServiceTest {
         service = new ModerationService("test", "gpt-4.1-mini", 0.5, 60,
                 java.util.logging.Logger.getAnonymousLogger(), false,
                 ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10,
-                new okhttp3.OkHttpClient()) {
+                new okhttp3.OkHttpClient.Builder().build()) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -117,7 +117,7 @@ public class ModerationServiceTest {
         service = new ModerationService("test", "gpt-4.1-mini", 0.5, 60,
                 java.util.logging.Logger.getAnonymousLogger(), false,
                 ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10,
-                new okhttp3.OkHttpClient()) {
+                new okhttp3.OkHttpClient.Builder().build()) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -128,7 +128,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelTriggeredGpt41() throws Exception {
-        service = new ModerationService("test", "gpt-4.1", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10, new okhttp3.OkHttpClient()) {
+        service = new ModerationService("test", "gpt-4.1", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10, new okhttp3.OkHttpClient.Builder().build()) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -139,7 +139,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelNotTriggeredGpt41() throws Exception {
-        service = new ModerationService("test", "gpt-4.1", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10, new okhttp3.OkHttpClient()) {
+        service = new ModerationService("test", "gpt-4.1", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10, new okhttp3.OkHttpClient.Builder().build()) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -150,7 +150,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelTriggeredO3() throws Exception {
-        service = new ModerationService("test", "o3", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10, new okhttp3.OkHttpClient()) {
+        service = new ModerationService("test", "o3", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10, new okhttp3.OkHttpClient.Builder().build()) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -161,7 +161,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelNotTriggeredO3() throws Exception {
-        service = new ModerationService("test", "o3", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10, new okhttp3.OkHttpClient()) {
+        service = new ModerationService("test", "o3", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10, new okhttp3.OkHttpClient.Builder().build()) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -172,7 +172,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelTriggeredO4Mini() throws Exception {
-        service = new ModerationService("test", "o4-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10, new okhttp3.OkHttpClient()) {
+        service = new ModerationService("test", "o4-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10, new okhttp3.OkHttpClient.Builder().build()) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };
@@ -183,7 +183,7 @@ public class ModerationServiceTest {
 
     @Test
     public void testChatModelNotTriggeredO4Mini() throws Exception {
-        service = new ModerationService("test", "o4-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10, new okhttp3.OkHttpClient()) {
+        service = new ModerationService("test", "o4-mini", 0.5, 60, java.util.logging.Logger.getAnonymousLogger(), false, ModerationService.DEFAULT_SYSTEM_PROMPT, "medium", 10, new okhttp3.OkHttpClient.Builder().build()) {
             @Override
             protected String getChatUrl() { return server.url("/v1/chat/completions").toString(); }
         };


### PR DESCRIPTION
## Summary
- build OkHttp client with dispatcher and timeouts
- allow tuning these values in `config.yml`
- update `ModerationServiceTest` for builder usage
- document the new options

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6851c5ef6fec8330825f179462a447d5