### PR TITLE
Add Discord command menu and API

### DIFF
--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -5,6 +5,10 @@ const {
   ActionRowBuilder,
   ButtonBuilder,
   ButtonStyle,
+  StringSelectMenuBuilder,
+  ModalBuilder,
+  TextInputBuilder,
+  TextInputStyle,
   SlashCommandBuilder,
   REST,
   Routes
@@ -30,10 +34,57 @@ const commands = [
       o.setName('count')
         .setDescription('Number of entries to show')
         .setMinValue(1))
+    .toJSON(),
+  new SlashCommandBuilder()
+    .setName('cm')
+    .setDescription('ChatModeration commands')
+    .addSubcommand(sc => sc.setName('menu').setDescription('Show command menu'))
+    .addSubcommand(sc => sc.setName('mute').setDescription('Mute a player')
+      .addStringOption(o => o.setName('player').setDescription('Player name').setRequired(true))
+      .addIntegerOption(o => o.setName('minutes').setDescription('Duration in minutes').setRequired(true)))
+    .addSubcommand(sc => sc.setName('unmute').setDescription('Unmute a player')
+      .addStringOption(o => o.setName('player').setDescription('Player name').setRequired(true)))
+    .addSubcommand(sc => sc.setName('status').setDescription('Check mute status')
+      .addStringOption(o => o.setName('player').setDescription('Player name').setRequired(true)))
+    .addSubcommand(sc => sc.setName('reload').setDescription('Reload plugin'))
+    .addSubcommand(sc => sc.setName('logs').setDescription('Show logs')
+      .addIntegerOption(o => o.setName('count').setDescription('Number of entries').setMinValue(1)))
+    .addSubcommand(sc => sc.setName('clearlogs').setDescription('Clear log entries'))
     .toJSON()
 ];
 
 const rest = new REST({ version: '10' }).setToken(token);
+
+async function sendMenu(channel, ephemeralTarget) {
+  const desc = [
+    '/cm mute <player> <minutes> - mute player',
+    '/cm unmute <player> - unmute player',
+    '/cm status <player> - check mute status',
+    '/cm reload - reload plugin',
+    '/cm logs [count] - show logs',
+    '/cm clearlogs - clear logs'
+  ].join('\n');
+
+  const menu = new StringSelectMenuBuilder()
+    .setCustomId('cm-menu')
+    .setPlaceholder('Choose command')
+    .addOptions(
+      { label: 'Mute', value: 'mute' },
+      { label: 'Unmute', value: 'unmute' },
+      { label: 'Status', value: 'status' },
+      { label: 'Reload', value: 'reload' },
+      { label: 'Logs', value: 'logs' },
+      { label: 'Clear Logs', value: 'clearlogs' }
+    );
+
+  const row = new ActionRowBuilder().addComponents(menu);
+  const payload = { content: desc, components: [row] };
+  if (ephemeralTarget) {
+    await ephemeralTarget.reply({ ...payload, ephemeral: true });
+  } else {
+    await channel.send(payload);
+  }
+}
 
 (async () => {
   try {
@@ -58,16 +109,20 @@ client.once('ready', () => {
 });
 
 client.on('messageCreate', async (message) => {
-  if (!message.content.startsWith(prefix + 'logs')) return;
-  const parts = message.content.trim().split(/\s+/);
-  const count = parseInt(parts[1], 10) || 5;
-  try {
-    const logs = await fs.readJson(logFile);
-    const latest = logs.slice(-count).map(l => `${new Date(l.timestamp).toLocaleString()} - **${l.name}**: ${l.message}`).join('\n');
-    await message.channel.send({ content: latest || 'No logs found.' });
-  } catch (err) {
-    console.error('Failed to read log file', err);
-    await message.channel.send({ content: 'Could not read log file.' });
+  if (message.author.bot) return;
+  if (message.content.startsWith(prefix + 'logs')) {
+    const parts = message.content.trim().split(/\s+/);
+    const count = parseInt(parts[1], 10) || 5;
+    try {
+      const logs = await fs.readJson(logFile);
+      const latest = logs.slice(-count).map(l => `${new Date(l.timestamp).toLocaleString()} - **${l.name}**: ${l.message}`).join('\n');
+      await message.channel.send({ content: latest || 'No logs found.' });
+    } catch (err) {
+      console.error('Failed to read log file', err);
+      await message.channel.send({ content: 'Could not read log file.' });
+    }
+  } else if (message.content.trim() === prefix + 'cm') {
+    await sendMenu(message.channel);
   }
 });
 
@@ -86,6 +141,97 @@ client.on('interactionCreate', async (interaction) => {
       console.error('Failed to unmute', err);
       await interaction.reply({ content: 'Failed to unmute.', ephemeral: true });
     }
+  } else if (interaction.isStringSelectMenu() && interaction.customId === 'cm-menu') {
+    const choice = interaction.values[0];
+    if (choice === 'reload') {
+      await fetch(`${pluginUrl}/reload`, { method: 'POST' });
+      await interaction.reply({ content: 'Plugin reloaded.', ephemeral: true });
+    } else if (choice === 'clearlogs') {
+      await fetch(`${pluginUrl}/clearlogs`, { method: 'POST' });
+      await interaction.reply({ content: 'Logs cleared.', ephemeral: true });
+    } else if (choice === 'logs') {
+      const resp = await fetch(`${pluginUrl}/logs?count=5`);
+      const logs = await resp.json();
+      const latest = logs.map(l => `${new Date(l.timestamp).toLocaleString()} - **${l.name}**: ${l.message}`).join('\n');
+      await interaction.reply({ content: latest || 'No logs found.', ephemeral: true });
+    } else if (choice === 'mute') {
+      const modal = new ModalBuilder()
+        .setCustomId('cm-mute')
+        .setTitle('Mute Player')
+        .addComponents(
+          new ActionRowBuilder().addComponents(
+            new TextInputBuilder()
+              .setCustomId('player')
+              .setLabel('Player')
+              .setStyle(TextInputStyle.Short)
+              .setRequired(true)
+          ),
+          new ActionRowBuilder().addComponents(
+            new TextInputBuilder()
+              .setCustomId('minutes')
+              .setLabel('Minutes')
+              .setStyle(TextInputStyle.Short)
+              .setRequired(true)
+          )
+        );
+      await interaction.showModal(modal);
+    } else if (choice === 'unmute') {
+      const modal = new ModalBuilder()
+        .setCustomId('cm-unmute')
+        .setTitle('Unmute Player')
+        .addComponents(
+          new ActionRowBuilder().addComponents(
+            new TextInputBuilder()
+              .setCustomId('player')
+              .setLabel('Player')
+              .setStyle(TextInputStyle.Short)
+              .setRequired(true)
+          )
+        );
+      await interaction.showModal(modal);
+    } else if (choice === 'status') {
+      const modal = new ModalBuilder()
+        .setCustomId('cm-status')
+        .setTitle('Status')
+        .addComponents(
+          new ActionRowBuilder().addComponents(
+            new TextInputBuilder()
+              .setCustomId('player')
+              .setLabel('Player')
+              .setStyle(TextInputStyle.Short)
+              .setRequired(true)
+          )
+        );
+      await interaction.showModal(modal);
+    }
+  } else if (interaction.isModalSubmit()) {
+    if (interaction.customId === 'cm-mute') {
+      const player = interaction.fields.getTextInputValue('player');
+      const minutes = parseInt(interaction.fields.getTextInputValue('minutes'), 10);
+      await fetch(`${pluginUrl}/mute`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ player, minutes })
+      });
+      await interaction.reply({ content: `Muted ${player} for ${minutes} minutes`, ephemeral: true });
+    } else if (interaction.customId === 'cm-unmute') {
+      const player = interaction.fields.getTextInputValue('player');
+      await fetch(`${pluginUrl}/unmute`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ player })
+      });
+      await interaction.reply({ content: `Unmuted ${player}`, ephemeral: true });
+    } else if (interaction.customId === 'cm-status') {
+      const player = interaction.fields.getTextInputValue('player');
+      const resp = await fetch(`${pluginUrl}/status?player=${encodeURIComponent(player)}`);
+      const data = await resp.json();
+      if (data.muted) {
+        await interaction.reply({ content: `${player} muted for ${data.remaining}m`, ephemeral: true });
+      } else {
+        await interaction.reply({ content: `${player} is not muted`, ephemeral: true });
+      }
+    }
   } else if (interaction.isChatInputCommand() && interaction.commandName === 'logs') {
     const count = interaction.options.getInteger('count') ?? 5;
     try {
@@ -95,6 +241,49 @@ client.on('interactionCreate', async (interaction) => {
     } catch (err) {
       console.error('Failed to read log file', err);
       await interaction.reply({ content: 'Could not read log file.' });
+    }
+  } else if (interaction.isChatInputCommand() && interaction.commandName === 'cm') {
+    const sub = interaction.options.getSubcommand();
+    if (sub === 'menu') {
+      await sendMenu(null, interaction);
+    } else if (sub === 'reload') {
+      await fetch(`${pluginUrl}/reload`, { method: 'POST' });
+      await interaction.reply({ content: 'Plugin reloaded.', ephemeral: true });
+    } else if (sub === 'clearlogs') {
+      await fetch(`${pluginUrl}/clearlogs`, { method: 'POST' });
+      await interaction.reply({ content: 'Logs cleared.', ephemeral: true });
+    } else if (sub === 'logs') {
+      const count = interaction.options.getInteger('count') ?? 5;
+      const resp = await fetch(`${pluginUrl}/logs?count=${count}`);
+      const data = await resp.json();
+      const latest = data.map(l => `${new Date(l.timestamp).toLocaleString()} - **${l.name}**: ${l.message}`).join('\n');
+      await interaction.reply({ content: latest || 'No logs found.', ephemeral: true });
+    } else if (sub === 'mute') {
+      const player = interaction.options.getString('player');
+      const minutes = interaction.options.getInteger('minutes');
+      await fetch(`${pluginUrl}/mute`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ player, minutes })
+      });
+      await interaction.reply({ content: `Muted ${player} for ${minutes} minutes`, ephemeral: true });
+    } else if (sub === 'unmute') {
+      const player = interaction.options.getString('player');
+      await fetch(`${pluginUrl}/unmute`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ player })
+      });
+      await interaction.reply({ content: `Unmuted ${player}`, ephemeral: true });
+    } else if (sub === 'status') {
+      const player = interaction.options.getString('player');
+      const resp = await fetch(`${pluginUrl}/status?player=${encodeURIComponent(player)}`);
+      const data = await resp.json();
+      if (data.muted) {
+        await interaction.reply({ content: `${player} muted for ${data.remaining}m`, ephemeral: true });
+      } else {
+        await interaction.reply({ content: `${player} is not muted`, ephemeral: true });
+      }
     }
   }
 });

--- a/src/main/java/me/ogulcan/chatmod/web/UnmuteServer.java
+++ b/src/main/java/me/ogulcan/chatmod/web/UnmuteServer.java
@@ -6,6 +6,7 @@ import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import me.ogulcan.chatmod.Main;
 import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,6 +25,12 @@ public class UnmuteServer {
         this.plugin = plugin;
         server = HttpServer.create(new InetSocketAddress(port), 0);
         server.createContext("/unmute", new UnmuteHandler());
+        server.createContext("/mute", new MuteHandler());
+        server.createContext("/status", new StatusHandler());
+        server.createContext("/reload", new ReloadHandler());
+        server.createContext("/clearlogs", new ClearLogsHandler());
+        server.createContext("/logs", new LogsHandler());
+        server.createContext("/command", new CommandHandler());
         // Use a fixed thread pool to handle concurrent requests
         server.setExecutor(Executors.newFixedThreadPool(threads));
         server.start();
@@ -57,6 +64,146 @@ public class UnmuteServer {
                 plugin.getStore().unmute(uuid);
                 plugin.cancelUnmute(uuid);
             });
+            byte[] resp = "{\"ok\":true}".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, resp.length);
+            exchange.getResponseBody().write(resp);
+        }
+    }
+
+    private class MuteHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            if (!"POST".equalsIgnoreCase(exchange.getRequestMethod())) {
+                exchange.sendResponseHeaders(405, -1);
+                return;
+            }
+            String body;
+            try (InputStream in = exchange.getRequestBody()) {
+                body = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            }
+            Map<?, ?> data = gson.fromJson(body, Map.class);
+            String player = data == null ? null : (String) data.get("player");
+            Number minutes = data == null ? null : (Number) data.get("minutes");
+            if (player == null || minutes == null) {
+                byte[] resp = "{\"error\":\"Missing fields\"}".getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(400, resp.length);
+                exchange.getResponseBody().write(resp);
+                return;
+            }
+            long min = minutes.longValue();
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                OfflinePlayer off = Bukkit.getOfflinePlayer(player);
+                plugin.getStore().mute(off.getUniqueId(), min);
+                plugin.scheduleUnmute(off.getUniqueId(), min * 60L * 20L);
+            });
+            byte[] resp = "{\"ok\":true}".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, resp.length);
+            exchange.getResponseBody().write(resp);
+        }
+    }
+
+    private class StatusHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            String player = null;
+            if ("GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+                String query = exchange.getRequestURI().getQuery();
+                if (query != null && query.startsWith("player=")) {
+                    player = query.substring(7);
+                }
+            } else if ("POST".equalsIgnoreCase(exchange.getRequestMethod())) {
+                String body;
+                try (InputStream in = exchange.getRequestBody()) {
+                    body = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+                }
+                Map<?, ?> data = gson.fromJson(body, Map.class);
+                player = data == null ? null : (String) data.get("player");
+            } else {
+                exchange.sendResponseHeaders(405, -1);
+                return;
+            }
+            if (player == null || player.isBlank()) {
+                byte[] resp = "{\"error\":\"Missing player\"}".getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(400, resp.length);
+                exchange.getResponseBody().write(resp);
+                return;
+            }
+            OfflinePlayer off = Bukkit.getOfflinePlayer(player);
+            boolean muted = plugin.getStore().isMuted(off.getUniqueId());
+            long remaining = muted ? plugin.getStore().remaining(off.getUniqueId()) / 60000 : 0;
+            byte[] resp = gson.toJson(Map.of("muted", muted, "remaining", remaining)).getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, resp.length);
+            exchange.getResponseBody().write(resp);
+        }
+    }
+
+    private class ReloadHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            if (!"POST".equalsIgnoreCase(exchange.getRequestMethod())) {
+                exchange.sendResponseHeaders(405, -1);
+                return;
+            }
+            Bukkit.getScheduler().runTask(plugin, plugin::reloadAll);
+            byte[] resp = "{\"ok\":true}".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, resp.length);
+            exchange.getResponseBody().write(resp);
+        }
+    }
+
+    private class ClearLogsHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            if (!"POST".equalsIgnoreCase(exchange.getRequestMethod())) {
+                exchange.sendResponseHeaders(405, -1);
+                return;
+            }
+            Bukkit.getScheduler().runTask(plugin, () -> plugin.getLogStore().clear());
+            byte[] resp = "{\"ok\":true}".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, resp.length);
+            exchange.getResponseBody().write(resp);
+        }
+    }
+
+    private class LogsHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            int count = 5;
+            String query = exchange.getRequestURI().getQuery();
+            if (query != null && query.startsWith("count=")) {
+                try {
+                    count = Integer.parseInt(query.substring(6));
+                } catch (NumberFormatException ignored) {}
+            }
+            var logs = plugin.getLogStore().getLogs();
+            int from = Math.max(0, logs.size() - count);
+            var slice = logs.subList(from, logs.size());
+            byte[] resp = gson.toJson(slice).getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, resp.length);
+            exchange.getResponseBody().write(resp);
+        }
+    }
+
+    private class CommandHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            if (!"POST".equalsIgnoreCase(exchange.getRequestMethod())) {
+                exchange.sendResponseHeaders(405, -1);
+                return;
+            }
+            String body;
+            try (InputStream in = exchange.getRequestBody()) {
+                body = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            }
+            Map<?, ?> data = gson.fromJson(body, Map.class);
+            String cmd = data == null ? null : (String) data.get("command");
+            if (cmd == null || cmd.isBlank()) {
+                byte[] resp = "{\"error\":\"Missing command\"}".getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(400, resp.length);
+                exchange.getResponseBody().write(resp);
+                return;
+            }
+            Bukkit.getScheduler().runTask(plugin, () -> Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd));
             byte[] resp = "{\"ok\":true}".getBytes(StandardCharsets.UTF_8);
             exchange.sendResponseHeaders(200, resp.length);
             exchange.getResponseBody().write(resp);


### PR DESCRIPTION
## Summary
- expand plugin HTTP server with new command endpoints
- add interactive command menu in Discord bot

## Testing
- `gradle wrapper`
- `./gradlew test`
- `node --check discord-bot/index.js`

------
https://chatgpt.com/codex/tasks/task_e_6851ddac45b88330aa277483df67adaf