### PR TITLE
Add reason option to manual mutes

### DIFF
--- a/src/main/java/me/ogulcan/chatmod/Main.java
+++ b/src/main/java/me/ogulcan/chatmod/Main.java
@@ -109,6 +109,10 @@ public class Main extends JavaPlugin {
         return messages;
     }
 
+    public DiscordNotifier getNotifier() {
+        return notifier;
+    }
+
     public FileConfiguration getGuiConfig() {
         return guiConfig;
     }

--- a/src/main/java/me/ogulcan/chatmod/command/CmCommand.java
+++ b/src/main/java/me/ogulcan/chatmod/command/CmCommand.java
@@ -70,7 +70,10 @@ public class CmCommand implements CommandExecutor {
             sender.sendMessage(plugin.getMessages().get("invalid-minutes"));
             return true;
         }
+        String reason = args.length > 2 ? String.join(" ", Arrays.copyOfRange(args, 2, args.length)) : "";
         store.mute(target.getUniqueId(), minutes);
+        plugin.getLogStore().add(target.getUniqueId(), target.getName(), reason.isBlank() ? "manual" : reason, true);
+        plugin.getNotifier().notifyMute(target.getName(), reason.isBlank() ? "manual" : reason, minutes);
         plugin.scheduleUnmute(target.getUniqueId(), minutes * 60L * 20L);
         sender.sendMessage(plugin.getMessages().get("muted", target.getName(), minutes));
         return true;

--- a/src/main/java/me/ogulcan/chatmod/gui/LogsGUI.java
+++ b/src/main/java/me/ogulcan/chatmod/gui/LogsGUI.java
@@ -60,7 +60,11 @@ public class LogsGUI implements Listener {
             meta.setDisplayName(ChatColor.YELLOW + entry.name);
             List<String> lore = new ArrayList<>();
             String msg = entry.message.length() > 30 ? entry.message.substring(0, 30) + "..." : entry.message;
-            lore.add(ChatColor.GRAY + msg);
+            if (entry.manual) {
+                lore.add(ChatColor.LIGHT_PURPLE + "[Manual] " + msg);
+            } else {
+                lore.add(ChatColor.GRAY + msg);
+            }
             DateTimeFormatter fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
                     .withZone(ZoneId.systemDefault());
             lore.add(ChatColor.AQUA + fmt.format(Instant.ofEpochMilli(entry.timestamp)));

--- a/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
+++ b/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
@@ -115,7 +115,7 @@ public class ChatListener implements Listener {
                     .forEach(p -> p.sendMessage(msg));
         }
         store.mute(uuid, minutes);
-        logStore.add(uuid, player.getName(), message);
+        logStore.add(uuid, player.getName(), message, false);
         plugin.scheduleUnmute(uuid, minutes * 60L * 20L);
         player.sendMessage(plugin.getMessages().get("muted-player", minutes));
 

--- a/src/main/java/me/ogulcan/chatmod/storage/LogStore.java
+++ b/src/main/java/me/ogulcan/chatmod/storage/LogStore.java
@@ -47,7 +47,11 @@ public class LogStore {
     }
 
     public synchronized void add(UUID uuid, String name, String message) {
-        logs.add(new LogEntry(uuid, name, message, System.currentTimeMillis()));
+        add(uuid, name, message, false);
+    }
+
+    public synchronized void add(UUID uuid, String name, String message, boolean manual) {
+        logs.add(new LogEntry(uuid, name, message, System.currentTimeMillis(), manual));
         int max = plugin.getConfig().getInt("max-log-entries", 1000);
         if (max > 0) {
             while (logs.size() > max) {
@@ -110,12 +114,14 @@ public class LogStore {
         public String name;
         public String message;
         public long timestamp;
+        public boolean manual;
 
-        public LogEntry(UUID uuid, String name, String message, long timestamp) {
+        public LogEntry(UUID uuid, String name, String message, long timestamp, boolean manual) {
             this.uuid = uuid;
             this.name = name;
             this.message = message;
             this.timestamp = timestamp;
+            this.manual = manual;
         }
     }
 }

--- a/src/main/java/me/ogulcan/chatmod/web/UnmuteServer.java
+++ b/src/main/java/me/ogulcan/chatmod/web/UnmuteServer.java
@@ -84,6 +84,7 @@ public class UnmuteServer {
             Map<?, ?> data = gson.fromJson(body, Map.class);
             String player = data == null ? null : (String) data.get("player");
             Number minutes = data == null ? null : (Number) data.get("minutes");
+            String reason = data == null ? null : (String) data.get("reason");
             if (player == null || minutes == null) {
                 byte[] resp = "{\"error\":\"Missing fields\"}".getBytes(StandardCharsets.UTF_8);
                 exchange.sendResponseHeaders(400, resp.length);
@@ -94,6 +95,8 @@ public class UnmuteServer {
             Bukkit.getScheduler().runTask(plugin, () -> {
                 OfflinePlayer off = Bukkit.getOfflinePlayer(player);
                 plugin.getStore().mute(off.getUniqueId(), min);
+                plugin.getLogStore().add(off.getUniqueId(), player, reason == null || reason.isBlank() ? "manual" : reason, true);
+                plugin.getNotifier().notifyMute(player, reason == null || reason.isBlank() ? "manual" : reason, min);
                 plugin.scheduleUnmute(off.getUniqueId(), min * 60L * 20L);
             });
             byte[] resp = "{\"ok\":true}".getBytes(StandardCharsets.UTF_8);


### PR DESCRIPTION
## Summary
- allow specifying reason in `/cm mute`
- store manual mutes with reason in `LogStore`
- show `[Manual]` tag in Logs GUI and Discord bot log displays
- expose notifier getter and log manual mutes from web API
- update Discord bot commands, modal and log formatting

## Testing
- `gradle wrapper`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_6851ecf108108330aa34c9a2dbe0b3ed