### PR TITLE
Improve mute notifications with embed

### DIFF
--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -37,7 +37,7 @@ and provides a `/logs` slash command (plus an optional prefix command) to displa
 }
 ```
 
-The bot announces the mute in the configured channel using a styled embed. The embed shows the muted player's Minecraft skin, lists the mute details in separate fields, and includes an **Unmute** button that triggers a request back to the plugin.
+The bot announces the mute in the configured channel using a styled embed. The embed shows the muted player's Minecraft skin. Type, date and muted by are displayed side by side, while the player name, duration and reason are stacked beneath. An **Unmute** button triggers a request back to the plugin.
 
 ## Commands
 

--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -37,7 +37,7 @@ and provides a `/logs` slash command (plus an optional prefix command) to displa
 }
 ```
 
-The bot announces the mute in the configured channel using a styled embed. The embed shows the muted player's Minecraft skin and includes an **Unmute** button that triggers a request back to the plugin.
+The bot announces the mute in the configured channel using a styled embed. The embed shows the muted player's Minecraft skin, lists the mute details in separate fields, and includes an **Unmute** button that triggers a request back to the plugin.
 
 ## Commands
 

--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -37,8 +37,7 @@ and provides a `/logs` slash command (plus an optional prefix command) to displa
 }
 ```
 
-The bot will announce the mute to the configured channel.
-The message includes an **Unmute** button that triggers a request to the plugin.
+The bot announces the mute in the configured channel using a styled embed. The embed shows the muted player's Minecraft skin and includes an **Unmute** button that triggers a request back to the plugin.
 
 ## Commands
 

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -470,8 +470,8 @@ app.post('/mute', async (req, res) => {
           { name: strings[lang].fieldMuteType, value: typeStr, inline: true },
           { name: strings[lang].fieldDate, value: date, inline: true },
           { name: strings[lang].fieldMutedBy, value: actor, inline: true },
-          { name: strings[lang].fieldMutedPlayer, value: player, inline: true },
-          { name: strings[lang].fieldDuration, value: duration, inline: true },
+          { name: strings[lang].fieldMutedPlayer, value: player },
+          { name: strings[lang].fieldDuration, value: duration },
           { name: strings[lang].fieldReason, value: reason || 'N/A' }
         );
       await channel.send({ embeds: [embed], components: [row] });

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -67,12 +67,18 @@ const strings = {
     statusUnmuted: '{0} is not muted',
     langChanged: 'Language set to {0}.',
     langUsage: 'Use /cm lang <en|tr> to change language.',
-    apiMute: 'Mute Type: {0}\nDate: {1}\nMuted By: {2}\nMuted Player: {3}\nDuration: {4}m\nReason: {5}',
     logFormat: '[{0}] {1} - **{3}** ({4}m) by {2}: {5}',
     type_game: 'In-Game Manual',
     type_discord: 'Discord Manual',
     type_auto: 'Automatic',
-    buttonUnmute: 'Unmute'
+    buttonUnmute: 'Unmute',
+    muteEmbedTitle: 'Mute Notice',
+    fieldMuteType: 'Type',
+    fieldDate: 'Date',
+    fieldMutedBy: 'Muted By',
+    fieldMutedPlayer: 'Player',
+    fieldDuration: 'Duration',
+    fieldReason: 'Reason'
   },
   tr: {
     menuLines: [
@@ -111,12 +117,18 @@ const strings = {
     statusUnmuted: '{0} susturulmamış',
     langChanged: 'Dil {0} olarak ayarlandı.',
     langUsage: '/cm lang <en|tr> komutunu kullanın.',
-    apiMute: 'Mute Biçimi: {0}\nTarih: {1}\nMute Atan Yetkili: {2}\nMute Atılan Oyuncu: {3}\nSüre: {4}dk\nSebep: {5}',
     logFormat: '[{0}] {1} - **{3}** ({4}dk) Yetkili: {2} | Sebep: {5}',
     type_game: 'Oyun İçi Manuel',
     type_discord: 'Discord Manuel',
     type_auto: 'Otomatik',
-    buttonUnmute: 'Kaldır'
+    buttonUnmute: 'Kaldır',
+    muteEmbedTitle: 'Susturma Bildirimi',
+    fieldMuteType: 'Biçim',
+    fieldDate: 'Tarih',
+    fieldMutedBy: 'Yetkili',
+    fieldMutedPlayer: 'Oyuncu',
+    fieldDuration: 'Süre',
+    fieldReason: 'Sebep'
   }
 };
 
@@ -448,13 +460,20 @@ app.post('/mute', async (req, res) => {
       );
       const date = new Date(timestamp || Date.now()).toLocaleString();
       const typeStr = strings[lang][`type_${type}`] || type;
-      const description = t('apiMute', typeStr, date, actor, player, remaining, reason);
+      const duration = `${remaining}${lang === 'tr' ? 'dk' : 'm'}`;
       const embed = new EmbedBuilder()
         .setColor(0xff5555)
-        .setTitle('Mute Notice')
-        .setDescription(description)
+        .setTitle(strings[lang].muteEmbedTitle)
         .setThumbnail(`https://mc-heads.net/avatar/${player}`)
-        .setImage(`https://mc-heads.net/body/${player}`);
+        .setImage(`https://mc-heads.net/body/${player}`)
+        .addFields(
+          { name: strings[lang].fieldMuteType, value: typeStr, inline: true },
+          { name: strings[lang].fieldDate, value: date, inline: true },
+          { name: strings[lang].fieldMutedBy, value: actor, inline: true },
+          { name: strings[lang].fieldMutedPlayer, value: player, inline: true },
+          { name: strings[lang].fieldDuration, value: duration, inline: true },
+          { name: strings[lang].fieldReason, value: reason || 'N/A' }
+        );
       await channel.send({ embeds: [embed], components: [row] });
     }
     res.json({ ok: true });

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -11,7 +11,8 @@ const {
   TextInputStyle,
   SlashCommandBuilder,
   REST,
-  Routes
+  Routes,
+  EmbedBuilder
 } = require('discord.js');
 const express = require('express');
 const fs = require('fs-extra');
@@ -447,8 +448,14 @@ app.post('/mute', async (req, res) => {
       );
       const date = new Date(timestamp || Date.now()).toLocaleString();
       const typeStr = strings[lang][`type_${type}`] || type;
-      const content = t('apiMute', typeStr, date, actor, player, remaining, reason);
-      await channel.send({ content, components: [row] });
+      const description = t('apiMute', typeStr, date, actor, player, remaining, reason);
+      const embed = new EmbedBuilder()
+        .setColor(0xff5555)
+        .setTitle('Mute Notice')
+        .setDescription(description)
+        .setThumbnail(`https://mc-heads.net/avatar/${player}`)
+        .setImage(`https://mc-heads.net/body/${player}`);
+      await channel.send({ embeds: [embed], components: [row] });
     }
     res.json({ ok: true });
   } catch (err) {


### PR DESCRIPTION
## Summary
- use `EmbedBuilder` for mute announcements
- show player's skin on embed
- document the embed-based notification

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_6852007d011483309aae199c0dbf3350