### PR TITLE
Add canonical word filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ The filter normalizes text when matching, converting Turkish letters like
 diacritics. Punctuation is converted to spaces so word boundaries are kept.
 Each token is checked against the block list and consecutive single-letter
 tokens are combined, allowing `s i k` to match a blocked word of `sik` while
+digits are mapped to similar letters (for example `s1k` becomes `sik`) and
+longer letter runs are collapsed so `siiiik` also triggers.
 
 ### GUI Customization
 A language-specific `gui_<lang>.yml` file controls the layout of the `/cm gui` dashboard. The `<lang>` part

--- a/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
+++ b/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
@@ -42,7 +42,7 @@ public class ChatListener implements Listener {
         this.categories = plugin.getConfig().getStringList("blocked-categories");
         this.words = plugin.getConfig().getStringList("blocked-words");
         this.normalizedWords = this.words.stream()
-                .map(WordFilter::normalize)
+                .map(WordFilter::canonicalize)
                 .collect(java.util.stream.Collectors.toSet());
         this.useBlockedWords = plugin.getConfig().getBoolean("use-blocked-words", true);
         this.useBlockedCategories = plugin.getConfig().getBoolean("use-blocked-categories", true);

--- a/src/test/java/me/ogulcan/chatmod/service/WordFilterTest.java
+++ b/src/test/java/me/ogulcan/chatmod/service/WordFilterTest.java
@@ -38,9 +38,17 @@ public class WordFilterTest {
     }
 
     @Test
+    public void testCanonicalDetection() {
+        List<String> words = List.of("sik");
+        assertTrue(WordFilter.containsBlockedWord("siiiik", words));
+        assertTrue(WordFilter.containsBlockedWord("s1k", words));
+        assertTrue(WordFilter.containsBlockedWord("\u015F\u00EFkk", words));
+    }
+
+    @Test
     public void testNormalizedWordList() {
         Set<String> words = List.of("orospu", "piç").stream()
-                .map(WordFilter::normalize)
+                .map(WordFilter::canonicalize)
                 .collect(java.util.stream.Collectors.toSet());
         assertTrue(WordFilter.containsBlockedWord("Sen bir orospu çocuğusun", words, true));
     }
@@ -48,7 +56,7 @@ public class WordFilterTest {
     @Test
     public void testNormalizedWordListClean() {
         Set<String> words = List.of("orospu", "piç").stream()
-                .map(WordFilter::normalize)
+                .map(WordFilter::canonicalize)
                 .collect(java.util.stream.Collectors.toSet());
         assertFalse(WordFilter.containsBlockedWord("Merhaba nasılsın", words, true));
     }


### PR DESCRIPTION
## Summary
- map digits to letters and collapse repeated letters when canonicalizing
- add `WordFilter.canonicalize` and update the filter logic
- adapt `ChatListener` to precompute canonical word list
- test new canonicalization cases (`siiiik`, `s1k`, `şïkk`)
- document advanced blocking behaviour in README

## Testing
- `gradle wrapper`
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68520aa965108330a2bc3290272d5b97