### PR TITLE
Add regex support for blocked words

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ tokens are combined, allowing `s i k` to match a blocked word of `sik` while
 digits are mapped to similar letters (for example `s1k` becomes `sik`,
 `s2k` becomes `szk`, `g6k` becomes `ggk`, and `s9k` may match `sgk` or `sqk`) and
 longer letter runs are collapsed so `siiiik` also triggers.
+You can also prefix and suffix an entry with `/` to use a regular expression.
+These regex patterns are matched against the normalized text. For example
+`/bad(word)?/` would block both `bad` and `badword`.
 
 ### GUI Customization
 A language-specific `gui_<lang>.yml` file controls the layout of the `/cm gui` dashboard. The `<lang>` part

--- a/src/test/java/me/ogulcan/chatmod/service/WordFilterTest.java
+++ b/src/test/java/me/ogulcan/chatmod/service/WordFilterTest.java
@@ -73,4 +73,17 @@ public class WordFilterTest {
         assertFalse(WordFilter.containsBlockedWord("Merhaba nasılsın", words, true));
     }
 
+    @Test
+    public void testRegexMatch() {
+        List<String> words = List.of("/bad(word)?/");
+        assertTrue(WordFilter.containsBlockedWord("such a badword indeed", words));
+    }
+
+    @Test
+    public void testRegexPrecompiledList() {
+        Set<String> words = Set.of("foo");
+        List<java.util.regex.Pattern> patterns = List.of(java.util.regex.Pattern.compile("bad(word)?"));
+        assertTrue(WordFilter.containsBlockedWord("another badword", words, patterns, true));
+    }
+
 }


### PR DESCRIPTION
## Summary
- allow regex entries in the blocked-word list and compile once
- parse regex patterns in `ChatListener`
- update README with regex docs
- add new unit tests for regex matching

## Testing
- `gradle wrapper`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_685265004fd083308f8dbb76e69985c7