### PR TITLE
Ensure blocked word filter enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ section. Set `enabled` to `false` to disable muting for a category or adjust the
 `ratio` value to change the score threshold used for that category. If a
 specific ratio is not provided, the global `threshold` option is used.
 You can also define `blocked-words` for custom profanity detection. Any chat message
-containing one of these words will be muted without an API call. Set `use-blocked-words`
-to `false` to disable this list-based filter and rely solely on the OpenAI model.
+containing one of these words will be muted without an API call. **`use-blocked-words`
+must be `true` for this filter to operate;** set it to `false` if you want to rely solely
+on the OpenAI model.
 The filter normalizes text when matching, converting Turkish letters like
 `ş`, `ö`, `ç`, `ğ`, `ı` and `ü` to their ASCII equivalents and removing other
 diacritics. Punctuation is converted to spaces so word boundaries are kept.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -79,7 +79,8 @@ countdown-offline: true
 max-log-entries: 1000
 save-interval-ticks: 100
 use-blocked-categories: true
-use-blocked-words: FALSE
+# When true, messages are scanned against the blocked-words list before using the API
+use-blocked-words: true
 blocked-words:
   - amk
   - orospu


### PR DESCRIPTION
## Summary
- document that `use-blocked-words` must be true in order to use the block list
- set `use-blocked-words` default to `true` in the example config

## Testing
- `gradle wrapper`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_685266e3f7348330afcbe95564830995