### PR TITLE
Improve WordFilter with Levenshtein distance

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ tokens are combined, allowing `s i k` to match a blocked word of `sik` while
 digits are mapped to similar letters (for example `s1k` becomes `sik`,
 `s2k` becomes `szk`, `g6k` becomes `ggk`, and `s9k` may match `sgk` or `sqk`) and
 longer letter runs are collapsed so `siiiik` also triggers.
+Words within a small Levenshtein distance can also trigger the filter. The
+`blocked-word-distance` option (default `1`) controls how many edits are
+allowed when comparing each token to a blocked word.
 You can also prefix and suffix an entry with `/` to use a regular expression.
 These regex patterns are matched against the normalized text. For example
 `/bad(word)?/` would block both `bad` and `badword`.

--- a/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
+++ b/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
@@ -32,6 +32,7 @@ public class ChatListener implements Listener {
     private final java.util.List<Pattern> regexPatterns;
     private final boolean useBlockedWords;
     private final boolean useBlockedCategories;
+    private final int blockedWordDistance;
     private final Map<String, Boolean> categoryEnabled;
     private final Map<String, Double> categoryRatio;
 
@@ -53,6 +54,7 @@ public class ChatListener implements Listener {
             }
         }
         this.useBlockedWords = plugin.getConfig().getBoolean("use-blocked-words", true);
+        this.blockedWordDistance = plugin.getConfig().getInt("blocked-word-distance", 1);
         this.useBlockedCategories = plugin.getConfig().getBoolean("use-blocked-categories", true);
         this.categoryEnabled = new HashMap<>();
         this.categoryRatio = new HashMap<>();
@@ -80,7 +82,7 @@ public class ChatListener implements Listener {
         if (player.hasPermission("chatmoderation.bypass")) return;
         String message = event.getMessage();
         if (BetterTeamsHook.isTeamChat(player, message)) return;
-        if (useBlockedWords && WordFilter.containsBlockedWord(message, normalizedWords, regexPatterns, true)) {
+        if (useBlockedWords && WordFilter.containsBlockedWord(message, normalizedWords, regexPatterns, true, blockedWordDistance)) {
             Bukkit.getScheduler().runTask(plugin, () -> applyPunishment(player, message));
             return;
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -81,6 +81,7 @@ save-interval-ticks: 100
 use-blocked-categories: true
 # When true, messages are scanned against the blocked-words list before using the API
 use-blocked-words: true
+blocked-word-distance: 1
 blocked-words:
   - amk
   - orospu

--- a/src/test/java/me/ogulcan/chatmod/service/WordFilterTest.java
+++ b/src/test/java/me/ogulcan/chatmod/service/WordFilterTest.java
@@ -92,4 +92,16 @@ public class WordFilterTest {
         assertTrue(WordFilter.containsBlockedWord("another badword", words, patterns, true));
     }
 
+    @Test
+    public void testLevenshteinMissingChar() {
+        List<String> words = List.of("sik");
+        assertTrue(WordFilter.containsBlockedWord("s*k", words, 1));
+    }
+
+    @Test
+    public void testLevenshteinSubstitution() {
+        List<String> words = List.of("sik");
+        assertTrue(WordFilter.containsBlockedWord("slk", words, 1));
+    }
+
 }


### PR DESCRIPTION
## Summary
- add Levenshtein helper and overload `WordFilter.containsBlockedWord`
- support configurable edit distance and use it in `ChatListener`
- document new `blocked-word-distance` setting
- add tests for distance detection

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68526c40ca04833091e70af6c426ec82