### PR TITLE
Add custom character mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,15 +73,33 @@ diacritics. Confusable characters from other alphabets such as Cyrillic `а`,
 `ѕ` or `е` are also mapped to their ASCII forms. Punctuation is converted to
 spaces so word boundaries are kept.
 Each token is checked against the block list and consecutive single-letter
-tokens are combined, allowing `s i k` to match a blocked word of `sik` while
-digits are mapped to similar letters (for example `s1k` becomes `sik`,
-`s2k` becomes `szk`, `g6k` becomes `ggk`, and `s9k` may match `sgk` or `sqk`) and
-longer letter runs are collapsed so `siiiik` also triggers.
+tokens are combined, allowing `s i k` to match a blocked word of `sik`.
+Characters can be remapped through the `character-mapping` section of
+`config.yml`. By default digits are mapped to similar letters (for example
+`s1k` becomes `sik`, `s2k` becomes `szk`, `g6k` becomes `ggk`, and `s9k`
+may match `sgk` or `sqk`) and longer letter runs are collapsed so `siiiik`
+also triggers.
 Words within a small Levenshtein distance can also trigger the filter. The
 `blocked-word-distance` option (default `1`) controls how many edits are
 allowed when comparing each token to a blocked word.
 You can also prefix and suffix an entry with `/` to use a regular expression.
 These regex patterns are matched against the normalized text. For example
+
+Example character mapping:
+```yml
+character-mapping:
+  '0': 'o'
+  '1': 'i'
+  '2': 'z'
+  '3': 'e'
+  '4': 'a'
+  '5': 's'
+  '6': 'g'
+  '7': 't'
+  '8': 'b'
+  '9': 'g'
+```
+
 `/bad(word)?/` would block both `bad` and `badword`.
 
 ### GUI Customization

--- a/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
+++ b/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
@@ -44,6 +44,19 @@ public class ChatListener implements Listener {
         this.notifier = notifier;
         this.categories = plugin.getConfig().getStringList("blocked-categories");
         this.words = plugin.getConfig().getStringList("blocked-words");
+
+        org.bukkit.configuration.ConfigurationSection mapSec =
+                plugin.getConfig().getConfigurationSection("character-mapping");
+        java.util.Map<Character, Character> charMap = new java.util.HashMap<>();
+        if (mapSec != null) {
+            for (String k : mapSec.getKeys(false)) {
+                String v = mapSec.getString(k);
+                if (k.length() == 1 && v != null && v.length() == 1) {
+                    charMap.put(k.charAt(0), v.charAt(0));
+                }
+            }
+        }
+        WordFilter.setCharacterMap(charMap);
         this.normalizedWords = new java.util.HashSet<>();
         this.regexPatterns = new java.util.ArrayList<>();
         for (String w : this.words) {

--- a/src/main/java/me/ogulcan/chatmod/service/WordFilter.java
+++ b/src/main/java/me/ogulcan/chatmod/service/WordFilter.java
@@ -25,9 +25,15 @@ public class WordFilter {
             Map.entry('і', 'i')  // Cyrillic i
     );
 
-    private static final java.util.Map<Character, Character> DIGIT_MAP =
+    private static java.util.Map<Character, Character> CHAR_MAP =
             java.util.Map.of('0', 'o', '1', 'i', '2', 'z', '3', 'e', '4', 'a',
                               '5', 's', '6', 'g', '7', 't', '8', 'b', '9', 'g');
+
+    public static void setCharacterMap(java.util.Map<Character, Character> map) {
+        if (map != null && !map.isEmpty()) {
+            CHAR_MAP = java.util.Map.copyOf(map);
+        }
+    }
 
     /**
      * Normalize text by converting to lowercase, replacing common Turkish
@@ -66,11 +72,7 @@ public class WordFilter {
 
         StringBuilder mapped = new StringBuilder();
         for (char c : normalized.toCharArray()) {
-            if (Character.isDigit(c) && DIGIT_MAP.containsKey(c)) {
-                mapped.append(DIGIT_MAP.get(c));
-            } else {
-                mapped.append(c);
-            }
+            mapped.append(CHAR_MAP.getOrDefault(c, c));
         }
 
         StringBuilder collapsed = new StringBuilder();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -89,3 +89,14 @@ blocked-words:
   - sik
   - yarak
   - got
+character-mapping:
+  '0': 'o'
+  '1': 'i'
+  '2': 'z'
+  '3': 'e'
+  '4': 'a'
+  '5': 's'
+  '6': 'g'
+  '7': 't'
+  '8': 'b'
+  '9': 'g'


### PR DESCRIPTION
## Summary
- support `character-mapping` section in default configuration
- load mapping in `ChatListener`
- let `WordFilter` replace characters using provided mapping
- document new option and show example

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68526e77e22483309f5e54c70b6e77a4