### PR TITLE
Support dynamic blocked-word refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,4 +178,6 @@ are persisted (default `100` ticks).
 
 Use `/cm reload` to re-read all configuration files. OpenAI options such as
 `openai-key`, `model`, `threshold` and `rate-limit` are applied immediately and
-event listeners are re-registered without restarting the server.
+event listeners are re-registered without restarting the server. Changes to the
+`blocked-words` list are also detected automatically when `config.yml` is saved
+so the filter updates without using this command.


### PR DESCRIPTION
## Summary
- watch `config.yml` and reload blocked words when it changes
- update the `ChatListener` word lists in a thread-safe manner
- document automatic reload capability for blocked words

## Testing
- `gradle wrapper --gradle-version=8.5`
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685270b7e4ac8330acf56ffe388041ef