### PR TITLE
Handle zero-width characters in word filter

### DIFF
--- a/src/main/java/me/ogulcan/chatmod/service/WordFilter.java
+++ b/src/main/java/me/ogulcan/chatmod/service/WordFilter.java
@@ -14,6 +14,8 @@ public class WordFilter {
     // Replace punctuation with spaces but keep letters, digits and whitespace
     private static final Pattern PUNCT = Pattern.compile("[^\\p{L}\\p{Nd}\\s]");
     private static final Pattern WHITESPACE = Pattern.compile("\\s+");
+    // Strip zero width characters which can split words
+    private static final Pattern ZERO_WIDTH = Pattern.compile("[\\u200B\\u200C\\u200D\\uFEFF]");
 
     // Map common confusable characters (e.g. Cyrillic letters) to ASCII
     private static final Map<Character, Character> CONFUSABLE_MAP = Map.ofEntries(
@@ -60,7 +62,8 @@ public class WordFilter {
                 .replace('ı', 'i');
         String nfd = Normalizer.normalize(lower, Normalizer.Form.NFD);
         String withoutDiacritics = DIACRITICS.matcher(nfd).replaceAll("");
-        String withSpaces = PUNCT.matcher(withoutDiacritics).replaceAll(" ");
+        String noZeroWidth = ZERO_WIDTH.matcher(withoutDiacritics).replaceAll("");
+        String withSpaces = PUNCT.matcher(noZeroWidth).replaceAll(" ");
         String base = WHITESPACE.matcher(withSpaces).replaceAll(" ").trim();
 
         StringBuilder replaced = new StringBuilder(base.length());

--- a/src/test/java/me/ogulcan/chatmod/service/WordFilterTest.java
+++ b/src/test/java/me/ogulcan/chatmod/service/WordFilterTest.java
@@ -64,6 +64,12 @@ public class WordFilterTest {
     }
 
     @Test
+    public void testZeroWidthCharacters() {
+        List<String> words = List.of("sik");
+        assertTrue(WordFilter.containsBlockedWord("s\u200Bi\u200Bk", words));
+    }
+
+    @Test
     public void testNormalizedWordList() {
         Set<String> words = List.of("orospu", "piç").stream()
                 .map(WordFilter::canonicalize)


### PR DESCRIPTION
## Summary
- strip zero width characters during normalization
- test detection of zero width characters

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6852737c22cc8330a83e65ade45db0fd