### PR TITLE
Add Zemberek stemming

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Enable `use-stemming` if you want the filter to also match simple word stems.
 For example a blocked word of `run` will also match `running` or `runner` when
 stemming is active. The stemmer supports English and Turkish based on the
 `language` setting.
+When the `language` is set to `tr`, enabling `use-zemberek` will use the
+Zemberek morphological analyzer so inflected forms like `sikleri` are detected
+even if only `sik` is in the blocked list.
 You can also prefix and suffix an entry with `/` to use a regular expression.
 These regex patterns are matched against the normalized text. For example
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ repositories {
     mavenCentral()
     maven("https://repo.papermc.io/repository/maven-public/")
     maven("https://jitpack.io")
+    maven("https://raw.githubusercontent.com/ahmetaa/maven-repo/master")
 }
 
 dependencies {
@@ -16,6 +17,7 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("com.google.code.gson:gson:2.10.1")
     implementation("com.github.rholder:snowball-stemmer:1.3.0.581.1")
+    implementation("zemberek-nlp:zemberek-morphology:0.17.1")
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     testImplementation("org.mockito:mockito-core:5.7.0")

--- a/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
+++ b/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
@@ -34,6 +34,7 @@ public class ChatListener implements Listener {
     private final boolean useBlockedCategories;
     private final int blockedWordDistance;
     private final boolean useStemming;
+    private final boolean useZemberek;
     private final Map<String, Boolean> categoryEnabled;
     private final Map<String, Double> categoryRatio;
 
@@ -62,6 +63,7 @@ public class ChatListener implements Listener {
         updateBlockedWords(words);
         this.useBlockedWords = plugin.getConfig().getBoolean("use-blocked-words", true);
         this.useStemming = plugin.getConfig().getBoolean("use-stemming", false);
+        this.useZemberek = plugin.getConfig().getBoolean("use-zemberek", false);
         this.blockedWordDistance = plugin.getConfig().getInt("blocked-word-distance", 1);
         this.useBlockedCategories = plugin.getConfig().getBoolean("use-blocked-categories", true);
         this.categoryEnabled = new HashMap<>();
@@ -90,7 +92,7 @@ public class ChatListener implements Listener {
         if (player.hasPermission("chatmoderation.bypass")) return;
         String message = event.getMessage();
         if (BetterTeamsHook.isTeamChat(player, message)) return;
-        if (useBlockedWords && WordFilter.containsBlockedWord(message, normalizedWords.get(), regexPatterns.get(), true, blockedWordDistance, useStemming)) {
+        if (useBlockedWords && WordFilter.containsBlockedWord(message, normalizedWords.get(), regexPatterns.get(), true, blockedWordDistance, useStemming, useZemberek)) {
             Bukkit.getScheduler().runTask(plugin, () -> applyPunishment(player, message));
             return;
         }

--- a/src/main/java/me/ogulcan/chatmod/service/ZemberekStemmer.java
+++ b/src/main/java/me/ogulcan/chatmod/service/ZemberekStemmer.java
@@ -1,0 +1,19 @@
+package me.ogulcan.chatmod.service;
+
+import zemberek.morphology.TurkishMorphology;
+import zemberek.morphology.analysis.WordAnalysis;
+import zemberek.morphology.analysis.SingleAnalysis;
+
+public class ZemberekStemmer {
+    private static final TurkishMorphology MORPHOLOGY = TurkishMorphology.createWithDefaults();
+
+    public static String lemma(String word) {
+        if (word == null || word.isEmpty()) return "";
+        WordAnalysis analysis = MORPHOLOGY.analyze(word);
+        if (analysis.analysisCount() == 0) return word;
+        SingleAnalysis best = analysis.getAnalysisResults().get(0);
+        java.util.List<String> lemmas = best.getLemmas();
+        if (lemmas.isEmpty()) return word;
+        return lemmas.get(0);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -83,6 +83,8 @@ use-blocked-categories: true
 use-blocked-words: true
 # Set to true to match stems so 'testing' also matches a blocked word of 'test'
 use-stemming: false
+# When language is 'tr', enable this to match lemmas using the Zemberek analyzer
+use-zemberek: false
 blocked-word-distance: 1
 blocked-words:
   - amk

--- a/src/test/java/me/ogulcan/chatmod/service/WordFilterTest.java
+++ b/src/test/java/me/ogulcan/chatmod/service/WordFilterTest.java
@@ -117,4 +117,11 @@ public class WordFilterTest {
         assertTrue(WordFilter.containsBlockedWord("running", words, java.util.Collections.emptyList(), true, 0, true));
     }
 
+    @Test
+    public void testZemberekLemmas() {
+        WordFilter.setLanguage("tr");
+        Set<String> words = Set.of(WordFilter.canonicalize("sik"));
+        assertTrue(WordFilter.containsBlockedWord("sikleri", words, java.util.Collections.emptyList(), true, 0, false, true));
+    }
+
 }


### PR DESCRIPTION
## Summary
- add Zemberek repository and dependency
- implement `ZemberekStemmer` for Turkish lemmatization
- support lemma matching in `WordFilter`
- expose new `use-zemberek` option in config and listener
- mention the new option in README
- test Turkish lemma matching

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68527c1e8ebc8330bc0b0e36789ff93b