### PR TITLE
Move blocked words to language files

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ Each category can also be tuned individually under the `category-settings`
 section. Set `enabled` to `false` to disable muting for a category or adjust the
 `ratio` value to change the score threshold used for that category. If a
 specific ratio is not provided, the global `threshold` option is used.
-You can also define `blocked-words` for custom profanity detection. Any chat message
+You can also define custom profanity lists in `blocked_words_en.yml` or
+`blocked_words_tr.yml` depending on the selected language. Any chat message
 containing one of these words will be muted without an API call. **`use-blocked-words`
 must be `true` for this filter to operate;** set it to `false` if you want to rely solely
 on the OpenAI model.
@@ -188,5 +189,5 @@ are persisted (default `100` ticks).
 Use `/cm reload` to re-read all configuration files. OpenAI options such as
 `openai-key`, `model`, `threshold` and `rate-limit` are applied immediately and
 event listeners are re-registered without restarting the server. Changes to the
-`blocked-words` list are also detected automatically when `config.yml` is saved
-so the filter updates without using this command.
+blocked words file are detected automatically so the filter updates without using
+this command.

--- a/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
+++ b/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
@@ -38,14 +38,15 @@ public class ChatListener implements Listener {
     private final Map<String, Boolean> categoryEnabled;
     private final Map<String, Double> categoryRatio;
 
-    public ChatListener(Main plugin, ModerationService service, PunishmentStore store, LogStore logStore, DiscordNotifier notifier) {
+    public ChatListener(Main plugin, ModerationService service, PunishmentStore store, LogStore logStore,
+                        DiscordNotifier notifier, java.util.List<String> blockedWords) {
         this.plugin = plugin;
         this.service = service;
         this.store = store;
         this.logStore = logStore;
         this.notifier = notifier;
         this.categories = plugin.getConfig().getStringList("blocked-categories");
-        java.util.List<String> words = plugin.getConfig().getStringList("blocked-words");
+        java.util.List<String> words = blockedWords;
 
         org.bukkit.configuration.ConfigurationSection mapSec =
                 plugin.getConfig().getConfigurationSection("character-mapping");

--- a/src/main/resources/blocked_words_en.yml
+++ b/src/main/resources/blocked_words_en.yml
@@ -1,0 +1,7 @@
+blocked-words:
+  - amk
+  - orospu
+  - pic
+  - sik
+  - yarak
+  - got

--- a/src/main/resources/blocked_words_tr.yml
+++ b/src/main/resources/blocked_words_tr.yml
@@ -1,0 +1,7 @@
+blocked-words:
+  - amk
+  - orospu
+  - pic
+  - sik
+  - yarak
+  - got

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -86,13 +86,6 @@ use-stemming: false
 # When language is 'tr', enable this to match lemmas using the Zemberek analyzer
 use-zemberek: false
 blocked-word-distance: 1
-blocked-words:
-  - amk
-  - orospu
-  - pic
-  - sik
-  - yarak
-  - got
 character-mapping:
   '0': 'o'
   '1': 'i'


### PR DESCRIPTION
## Summary
- create language-specific blocked_words_<lang>.yml files
- load and watch blocked word lists from these files
- update config and documentation

## Testing
- `gradle wrapper`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6852834977d88330969d9b1ff589db35