### PR TITLE
Fix Zemberek resource loading

### DIFF
--- a/src/main/java/me/ogulcan/chatmod/Main.java
+++ b/src/main/java/me/ogulcan/chatmod/Main.java
@@ -56,6 +56,9 @@ public class Main extends JavaPlugin {
         String effort = getConfig().getString("thinking-effort", "medium");
         long cacheMinutes = getConfig().getLong("moderation-cache-minutes", 5);
         boolean debug = getConfig().getBoolean("debug", false);
+        if (getConfig().getBoolean("use-zemberek", false)) {
+            me.ogulcan.chatmod.service.ZemberekStemmer.init();
+        }
         int connectTimeout = getConfig().getInt("http-connect-timeout", 10);
         int readTimeout = getConfig().getInt("http-read-timeout", 10);
         int maxRequests = getConfig().getInt("http-max-requests", 100);

--- a/src/main/java/me/ogulcan/chatmod/service/ZemberekStemmer.java
+++ b/src/main/java/me/ogulcan/chatmod/service/ZemberekStemmer.java
@@ -5,10 +5,30 @@ import zemberek.morphology.analysis.WordAnalysis;
 import zemberek.morphology.analysis.SingleAnalysis;
 
 public class ZemberekStemmer {
-    private static final TurkishMorphology MORPHOLOGY = TurkishMorphology.createWithDefaults();
+    private static TurkishMorphology MORPHOLOGY;
+
+    /**
+     * Lazily initialize the Zemberek morphology analyzer. This must run on a
+     * thread whose context class loader can access the plugin resources so the
+     * tokenization data files are found correctly.
+     */
+    public static synchronized void init() {
+        if (MORPHOLOGY == null) {
+            ClassLoader loader = ZemberekStemmer.class.getClassLoader();
+            Thread current = Thread.currentThread();
+            ClassLoader prev = current.getContextClassLoader();
+            try {
+                current.setContextClassLoader(loader);
+                MORPHOLOGY = TurkishMorphology.createWithDefaults();
+            } finally {
+                current.setContextClassLoader(prev);
+            }
+        }
+    }
 
     public static String lemma(String word) {
         if (word == null || word.isEmpty()) return "";
+        init();
         WordAnalysis analysis = MORPHOLOGY.analyze(word);
         if (analysis.analysisCount() == 0) return word;
         SingleAnalysis best = analysis.getAnalysisResults().get(0);


### PR DESCRIPTION
## Summary
- lazily initialize the Zemberek stemmer so it uses the plugin class loader
- init the stemmer during plugin startup when enabled

## Testing
- `./gradlew test`
- `./gradlew shadowJar`


------
https://chatgpt.com/codex/tasks/task_e_6852caca837c8330817509c015e10aed