### PR TITLE
Add UTF-8 encoding for JavaCompile tasks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,10 @@ java {
     toolchain.languageVersion.set(JavaLanguageVersion.of(21))
 }
 
+tasks.withType<JavaCompile> {
+    options.encoding = "UTF-8"
+}
+
 tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar") {
     archiveClassifier.set("")
     // Relocation removed due to ASM incompatibility with JDK 21


### PR DESCRIPTION
## Summary
- enforce UTF-8 encoding for all JavaCompile tasks in the Gradle build

## Testing
- `gradle wrapper --no-daemon`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6852def15ef8833091ae013333b598b4