### PR TITLE
Add fuzzy matching for blocked words

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ also triggers.
 Words within a small Levenshtein distance can also trigger the filter. The
 `blocked-word-distance` option (default `1`) controls how many edits are
 allowed when comparing each token to a blocked word.
+You can enable fuzzy matching by setting `fuzzy-threshold` to a value between
+`0` and `100`. When greater than zero the plugin uses a partial ratio fuzzy
+matcher and mutes messages when the similarity with a blocked word meets or
+exceeds this threshold.
 Enable `use-stemming` if you want the filter to also match simple word stems.
 For example a blocked word of `run` will also match `running` or `runner` when
 stemming is active. The stemmer supports English and Turkish based on the

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation("com.github.rholder:snowball-stemmer:1.3.0.581.1")
     implementation("zemberek-nlp:zemberek-morphology:0.17.1")
     implementation("zemberek-nlp:zemberek-tokenization:0.17.1")
+    implementation("me.xdrop:fuzzywuzzy:1.4.0")
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     testImplementation("org.mockito:mockito-core:5.7.0")

--- a/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
+++ b/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
@@ -33,6 +33,7 @@ public class ChatListener implements Listener {
     private final boolean useBlockedWords;
     private final boolean useBlockedCategories;
     private final int blockedWordDistance;
+    private final int fuzzyThreshold;
     private final boolean useStemming;
     private final boolean useZemberek;
     private final Map<String, Boolean> categoryEnabled;
@@ -66,6 +67,7 @@ public class ChatListener implements Listener {
         this.useStemming = plugin.getConfig().getBoolean("use-stemming", false);
         this.useZemberek = plugin.getConfig().getBoolean("use-zemberek", false);
         this.blockedWordDistance = plugin.getConfig().getInt("blocked-word-distance", 1);
+        this.fuzzyThreshold = plugin.getConfig().getInt("fuzzy-threshold", 0);
         this.useBlockedCategories = plugin.getConfig().getBoolean("use-blocked-categories", true);
         this.categoryEnabled = new HashMap<>();
         this.categoryRatio = new HashMap<>();
@@ -93,7 +95,7 @@ public class ChatListener implements Listener {
         if (player.hasPermission("chatmoderation.bypass")) return;
         String message = event.getMessage();
         if (BetterTeamsHook.isTeamChat(player, message)) return;
-        if (useBlockedWords && WordFilter.containsBlockedWord(message, normalizedWords.get(), regexPatterns.get(), true, blockedWordDistance, useStemming, useZemberek)) {
+        if (useBlockedWords && WordFilter.containsBlockedWord(message, normalizedWords.get(), regexPatterns.get(), true, blockedWordDistance, useStemming, useZemberek, fuzzyThreshold)) {
             Bukkit.getScheduler().runTask(plugin, () -> applyPunishment(player, message));
             return;
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -86,6 +86,7 @@ use-stemming: false
 # When language is 'tr', enable this to match lemmas using the Zemberek analyzer
 use-zemberek: false
 blocked-word-distance: 1
+fuzzy-threshold: 0
 character-mapping:
   '0': 'o'
   '1': 'i'

--- a/src/test/java/me/ogulcan/chatmod/service/WordFilterTest.java
+++ b/src/test/java/me/ogulcan/chatmod/service/WordFilterTest.java
@@ -111,17 +111,23 @@ public class WordFilterTest {
     }
 
     @Test
+    public void testFuzzyThreshold() {
+        List<String> words = List.of("sik");
+        assertTrue(WordFilter.containsBlockedWord("skik", words, 0, false, false, 60));
+    }
+
+    @Test
     public void testStemmingMatches() {
         WordFilter.setLanguage("en");
         Set<String> words = Set.of(WordFilter.canonicalize("run"));
-        assertTrue(WordFilter.containsBlockedWord("running", words, java.util.Collections.emptyList(), true, 0, true));
+        assertTrue(WordFilter.containsBlockedWord("running", words, java.util.Collections.<java.util.regex.Pattern>emptyList(), true, 0, true, false, 0));
     }
 
     @Test
     public void testZemberekLemmas() {
         WordFilter.setLanguage("tr");
         Set<String> words = Set.of(WordFilter.canonicalize("sik"));
-        assertTrue(WordFilter.containsBlockedWord("sikleri", words, java.util.Collections.emptyList(), true, 0, false, true));
+        assertTrue(WordFilter.containsBlockedWord("sikleri", words, java.util.Collections.<java.util.regex.Pattern>emptyList(), true, 0, false, true, 0));
     }
 
 }


### PR DESCRIPTION
## Summary
- add fuzzywuzzy dependency
- support fuzzy word checks in `WordFilter`
- expose new `fuzzy-threshold` option and use it in `ChatListener`
- document new setting in README
- update tests for fuzzy matching

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6852e4f1447083308d6e132e675f0b69