### PR TITLE
Improve fuzzy filter to ignore short tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ allowed when comparing each token to a blocked word.
 You can enable fuzzy matching by setting `fuzzy-threshold` to a value between
 `0` and `100`. When greater than zero the plugin uses a partial ratio fuzzy
 matcher and mutes messages when the similarity with a blocked word meets or
-exceeds this threshold.
+exceeds this threshold. Tokens shorter than two characters are ignored when
+fuzzy matching is active to avoid false positives with very short messages.
 Enable `use-stemming` if you want the filter to also match simple word stems.
 For example a blocked word of `run` will also match `running` or `runner` when
 stemming is active. The stemmer supports English and Turkish based on the

--- a/src/main/java/me/ogulcan/chatmod/service/WordFilter.java
+++ b/src/main/java/me/ogulcan/chatmod/service/WordFilter.java
@@ -288,7 +288,9 @@ public class WordFilter {
         }
         if (fuzzyThreshold > 0) {
             for (String token : words) {
+                if (token.length() <= 1) continue;
                 for (String w : normalizedWords) {
+                    if (w.length() <= 1) continue;
                     if (FuzzySearch.partialRatio(token, w) >= fuzzyThreshold) return true;
                 }
             }

--- a/src/test/java/me/ogulcan/chatmod/service/WordFilterTest.java
+++ b/src/test/java/me/ogulcan/chatmod/service/WordFilterTest.java
@@ -117,6 +117,12 @@ public class WordFilterTest {
     }
 
     @Test
+    public void testFuzzyThresholdSingleCharIgnored() {
+        List<String> words = List.of("sik");
+        assertFalse(WordFilter.containsBlockedWord("s", words, 0, false, false, 60));
+    }
+
+    @Test
     public void testStemmingMatches() {
         WordFilter.setLanguage("en");
         Set<String> words = Set.of(WordFilter.canonicalize("run"));


### PR DESCRIPTION
## Summary
- skip fuzzy matching for tokens shorter than two characters
- document fuzzy matching behavior in README
- add regression test for ignoring single characters

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68531b6ffd748330861ff89a6719f630