### PR TITLE
Improve word detection logic

### DIFF
--- a/src/main/java/me/ogulcan/chatmod/service/WordFilter.java
+++ b/src/main/java/me/ogulcan/chatmod/service/WordFilter.java
@@ -248,7 +248,9 @@ public class WordFilter {
         }
 
         for (String token : words) {
-            if (normalizedWords.stream().anyMatch(token::contains)) {
+            if (normalizedWords.stream().anyMatch(w ->
+                    token.equals(w) ||
+                    (token.contains(w) && token.length() - w.length() <= 4))) {
                 return true;
             }
             if (useZemberek && lemmaWords != null) {


### PR DESCRIPTION
## Summary
- tighten substring detection to avoid false positives on gibberish
- allow a small length margin so regular words like `running` still match

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6853204f4924833080338f5cd5550944