### PR TITLE
Add configurable prefix for chat messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The plugin generates `config.yml` on first run. **You must replace** the `openai
 value with your own API key or moderation requests will be skipped. Adjust
 thresholds or punishments as needed.
 Set `language` to `en` or `tr` to change plugin messages. The selected language file (`messages_en.yml` or `messages_tr.yml`) will be copied to the plugin folder so you can edit any text.
+Use the `prefix` option to customize the text added before all chat messages sent by the plugin.
 Enable `debug: true` in `config.yml` to log moderation responses and the selected moderation model for troubleshooting.
 Set `countdown-offline` to `false` if you want mute timers to pause while muted players are offline.
 Muted players are also blocked from using private messaging commands like `/msg`.

--- a/src/main/java/me/ogulcan/chatmod/command/CmCommand.java
+++ b/src/main/java/me/ogulcan/chatmod/command/CmCommand.java
@@ -24,14 +24,14 @@ public class CmCommand implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (args.length == 0) {
-            sender.sendMessage(plugin.getMessages().get("commands-title"));
-            sender.sendMessage(plugin.getMessages().get("command-mute"));
-            sender.sendMessage(plugin.getMessages().get("command-unmute"));
-            sender.sendMessage(plugin.getMessages().get("command-status"));
-            sender.sendMessage(plugin.getMessages().get("command-reload"));
-            sender.sendMessage(plugin.getMessages().get("command-gui"));
-            sender.sendMessage(plugin.getMessages().get("command-logs"));
-            sender.sendMessage(plugin.getMessages().get("command-clearlogs"));
+            sender.sendMessage(plugin.getMessages().prefixed("commands-title"));
+            sender.sendMessage(plugin.getMessages().prefixed("command-mute"));
+            sender.sendMessage(plugin.getMessages().prefixed("command-unmute"));
+            sender.sendMessage(plugin.getMessages().prefixed("command-status"));
+            sender.sendMessage(plugin.getMessages().prefixed("command-reload"));
+            sender.sendMessage(plugin.getMessages().prefixed("command-gui"));
+            sender.sendMessage(plugin.getMessages().prefixed("command-logs"));
+            sender.sendMessage(plugin.getMessages().prefixed("command-clearlogs"));
             return true;
         }
         String sub = args[0].toLowerCase();
@@ -58,19 +58,19 @@ public class CmCommand implements CommandExecutor {
 
     private boolean mute(CommandSender sender, String[] args) {
         if (args.length < 2) {
-            sender.sendMessage(plugin.getMessages().get("usage-mute"));
+            sender.sendMessage(plugin.getMessages().prefixed("usage-mute"));
             return true;
         }
         Player target = Bukkit.getPlayer(args[0]);
         if (target == null) {
-            sender.sendMessage(plugin.getMessages().get("player-not-found"));
+            sender.sendMessage(plugin.getMessages().prefixed("player-not-found"));
             return true;
         }
         long minutes;
         try {
             minutes = Long.parseLong(args[1]);
         } catch (NumberFormatException e) {
-            sender.sendMessage(plugin.getMessages().get("invalid-minutes"));
+            sender.sendMessage(plugin.getMessages().prefixed("invalid-minutes"));
             return true;
         }
         String reason = args.length > 2 ? String.join(" ", Arrays.copyOfRange(args, 2, args.length)) : "";
@@ -80,58 +80,58 @@ public class CmCommand implements CommandExecutor {
         plugin.getLogStore().add(target.getUniqueId(), target.getName(), r, "game", actor, minutes);
         plugin.getNotifier().notifyMute(target.getName(), r, minutes, actor, "game", System.currentTimeMillis());
         plugin.scheduleUnmute(target.getUniqueId(), minutes * 60L * 20L);
-        sender.sendMessage(plugin.getMessages().get("muted", target.getName(), minutes));
+        sender.sendMessage(plugin.getMessages().prefixed("muted", target.getName(), minutes));
         return true;
     }
 
     private boolean unmute(CommandSender sender, String[] args) {
         if (args.length < 1) {
-            sender.sendMessage(plugin.getMessages().get("usage-unmute"));
+            sender.sendMessage(plugin.getMessages().prefixed("usage-unmute"));
             return true;
         }
         Player target = Bukkit.getPlayer(args[0]);
         if (target == null) {
-            sender.sendMessage(plugin.getMessages().get("player-not-found"));
+            sender.sendMessage(plugin.getMessages().prefixed("player-not-found"));
             return true;
         }
         store.unmute(target.getUniqueId());
         plugin.cancelUnmute(target.getUniqueId());
-        sender.sendMessage(plugin.getMessages().get("unmuted", target.getName()));
+        sender.sendMessage(plugin.getMessages().prefixed("unmuted", target.getName()));
         return true;
     }
 
     private boolean status(CommandSender sender, String[] args) {
         if (args.length < 1) {
-            sender.sendMessage(plugin.getMessages().get("usage-status"));
+            sender.sendMessage(plugin.getMessages().prefixed("usage-status"));
             return true;
         }
         Player target = Bukkit.getPlayer(args[0]);
         if (target == null) {
-            sender.sendMessage(plugin.getMessages().get("player-not-found"));
+            sender.sendMessage(plugin.getMessages().prefixed("player-not-found"));
             return true;
         }
         if (store.isMuted(target.getUniqueId())) {
             long rem = store.remaining(target.getUniqueId()) / 1000;
-            sender.sendMessage(plugin.getMessages().get("remaining-mute", target.getName(), rem / 60, rem % 60));
+            sender.sendMessage(plugin.getMessages().prefixed("remaining-mute", target.getName(), rem / 60, rem % 60));
         } else {
-            sender.sendMessage(plugin.getMessages().get("not-muted", target.getName()));
+            sender.sendMessage(plugin.getMessages().prefixed("not-muted", target.getName()));
         }
         return true;
     }
 
     private boolean reload(CommandSender sender) {
         plugin.reloadAll();
-        sender.sendMessage(plugin.getMessages().get("reloaded"));
+        sender.sendMessage(plugin.getMessages().prefixed("reloaded"));
         return true;
     }
 
     private boolean gui(CommandSender sender) {
         if (!(sender instanceof Player player)) {
-            sender.sendMessage(plugin.getMessages().get("only-players"));
+            sender.sendMessage(plugin.getMessages().prefixed("only-players"));
             return true;
         }
         if (!player.hasPermission("chatmoderation.gui")) {
-            sender.sendMessage(plugin.getMessages().get("no-permission"));
+            sender.sendMessage(plugin.getMessages().prefixed("no-permission"));
             return true;
         }
         new DashboardGUI(plugin, store, plugin.getGuiConfig(), player).open();
@@ -140,11 +140,11 @@ public class CmCommand implements CommandExecutor {
 
     private boolean logs(CommandSender sender) {
         if (!(sender instanceof Player player)) {
-            sender.sendMessage(plugin.getMessages().get("only-players"));
+            sender.sendMessage(plugin.getMessages().prefixed("only-players"));
             return true;
         }
         if (!player.hasPermission("chatmoderation.logs")) {
-            sender.sendMessage(plugin.getMessages().get("no-permission"));
+            sender.sendMessage(plugin.getMessages().prefixed("no-permission"));
             return true;
         }
         new LogsGUI(plugin, plugin.getLogStore(), player);
@@ -153,7 +153,7 @@ public class CmCommand implements CommandExecutor {
 
     private boolean clearLogs(CommandSender sender) {
         plugin.getLogStore().clear();
-        sender.sendMessage(plugin.getMessages().get("logs-cleared"));
+        sender.sendMessage(plugin.getMessages().prefixed("logs-cleared"));
         return true;
     }
 }

--- a/src/main/java/me/ogulcan/chatmod/gui/DashboardGUI.java
+++ b/src/main/java/me/ogulcan/chatmod/gui/DashboardGUI.java
@@ -170,28 +170,28 @@ public class DashboardGUI implements Listener {
                             openingNew = true;
                             new LogsGUI(plugin, plugin.getLogStore(), viewer);
                         } else {
-                            viewer.sendMessage(plugin.getMessages().get("no-permission"));
+                            viewer.sendMessage(plugin.getMessages().prefixed("no-permission"));
                         }
                     } else if (viewer.hasPermission("chatmoderation.admin")) {
                         switch (btn.action) {
                         case "reload" -> {
                             plugin.reloadFiles();
                             this.gui = plugin.getGuiConfig();
-                            viewer.sendMessage(plugin.getMessages().get("reloaded"));
+                            viewer.sendMessage(plugin.getMessages().prefixed("reloaded"));
                             createMain();
                             openingNew = true;
                             viewer.openInventory(inventory);
                         }
                         case "clear" -> {
                             store.clear();
-                            viewer.sendMessage(plugin.getMessages().get("history-cleared"));
+                            viewer.sendMessage(plugin.getMessages().prefixed("history-cleared"));
                             createMain();
                             openingNew = true;
                             viewer.openInventory(inventory);
                         }
                         case "clear-logs" -> {
                             plugin.getLogStore().clear();
-                            viewer.sendMessage(plugin.getMessages().get("logs-cleared"));
+                            viewer.sendMessage(plugin.getMessages().prefixed("logs-cleared"));
                             createMain();
                             openingNew = true;
                             viewer.openInventory(inventory);

--- a/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
+++ b/src/main/java/me/ogulcan/chatmod/listener/ChatListener.java
@@ -88,7 +88,7 @@ public class ChatListener implements Listener {
         UUID uuid = player.getUniqueId();
         if (store.isMuted(uuid)) {
             long rem = store.remaining(uuid) / 1000;
-            player.sendMessage(plugin.getMessages().get("still-muted", format(rem)));
+            player.sendMessage(plugin.getMessages().prefixed("still-muted", format(rem)));
             event.setCancelled(true);
             return;
         }
@@ -132,7 +132,7 @@ public class ChatListener implements Listener {
             minutes = plugin.getConfig().getLong("punishments.third", 60);
         } else {
             minutes = plugin.getConfig().getLong("punishments.fourth", 180);
-            String msg = plugin.getMessages().get("repeated-offence", player.getName());
+            String msg = plugin.getMessages().prefixed("repeated-offence", player.getName());
             Bukkit.getOnlinePlayers().stream()
                     .filter(p -> p.hasPermission("chatmoderation.notify"))
                     .forEach(p -> p.sendMessage(msg));
@@ -142,12 +142,12 @@ public class ChatListener implements Listener {
         String autoReason = plugin.getMessages().get("auto-detection");
         logStore.add(uuid, player.getName(), autoReason, "auto", sys, minutes);
         plugin.scheduleUnmute(uuid, minutes * 60L * 20L);
-        player.sendMessage(plugin.getMessages().get("muted-player", minutes));
+        player.sendMessage(plugin.getMessages().prefixed("muted-player", minutes));
 
         // Broadcast mute information to all players
         int offences = store.offenceCount(uuid, Duration.ofHours(24).toMillis());
         long remaining = store.remaining(uuid) / 1000;
-        String broadcast = plugin.getMessages().get(
+        String broadcast = plugin.getMessages().prefixed(
                 "mute-broadcast",
                 player.getName(),
                 offences,

--- a/src/main/java/me/ogulcan/chatmod/listener/PrivateMessageListener.java
+++ b/src/main/java/me/ogulcan/chatmod/listener/PrivateMessageListener.java
@@ -33,7 +33,7 @@ public class PrivateMessageListener implements Listener {
         UUID uuid = player.getUniqueId();
         if (store.isMuted(uuid)) {
             long rem = store.remaining(uuid) / 1000;
-            player.sendMessage(plugin.getMessages().get("still-muted", format(rem)));
+            player.sendMessage(plugin.getMessages().prefixed("still-muted", format(rem)));
             event.setCancelled(true);
         }
     }

--- a/src/main/java/me/ogulcan/chatmod/task/UnmuteTask.java
+++ b/src/main/java/me/ogulcan/chatmod/task/UnmuteTask.java
@@ -25,7 +25,7 @@ public class UnmuteTask extends BukkitRunnable {
         plugin.cancelUnmute(uuid);
         Player player = Bukkit.getPlayer(uuid);
         if (player != null) {
-            player.sendMessage(plugin.getMessages().get("mute-expired"));
+            player.sendMessage(plugin.getMessages().prefixed("mute-expired"));
         }
     }
 }

--- a/src/main/java/me/ogulcan/chatmod/util/Messages.java
+++ b/src/main/java/me/ogulcan/chatmod/util/Messages.java
@@ -11,8 +11,10 @@ import java.text.MessageFormat;
 
 public class Messages {
     private final FileConfiguration config;
+    private final JavaPlugin plugin;
 
     public Messages(JavaPlugin plugin, String lang) {
+        this.plugin = plugin;
         String fileName = "messages_" + lang + ".yml";
         File dataFile = new File(plugin.getDataFolder(), fileName);
         if (!dataFile.exists()) {
@@ -34,5 +36,17 @@ public class Messages {
             msg = MessageFormat.format(msg, args);
         }
         return ChatColor.translateAlternateColorCodes('&', msg);
+    }
+
+    /**
+     * Return the translated message prefixed with the configured value.
+     */
+    public String prefixed(String key, Object... args) {
+        String msg = get(key, args);
+        String pfx = plugin.getConfig().getString("prefix", "");
+        if (pfx != null && !pfx.isBlank()) {
+            msg = ChatColor.translateAlternateColorCodes('&', pfx) + msg;
+        }
+        return msg;
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,6 @@
 openai-key: "REPLACE_ME"
 language: en
+prefix: "&7[ChatModeration] &r"
 # Set to 'gpt-4.1-mini', 'gpt-4.1', 'o3' or 'o4-mini' to use the chat model with a profanity check prompt
 model: omni-moderation-latest
 # Prompt used by the chat model


### PR DESCRIPTION
## Summary
- allow customizing the chat message prefix via `prefix` in `config.yml`
- add `Messages.prefixed` helper
- apply prefix to command and event messages
- document the new option

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to access jarfile gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685b241d8bac833097847454ebf6fcb7