### PR TITLE
Add OpenAI model guide

### DIFF
--- a/MODEL_GUIDE.md
+++ b/MODEL_GUIDE.md
@@ -1,0 +1,13 @@
+# OpenAI Model Guide
+
+This plugin can use several different OpenAI models for moderation.
+Below is a quick overview to help you decide which one fits your server best.
+
+- **omni-moderation-latest** – default moderation endpoint. Fast and inexpensive.
+- **gpt-4.1-mini** – lightweight chat model for extra nuance at a lower cost.
+- **gpt-4.1** – more capable chat model offering the highest accuracy.
+- **o3** – reasoning model with no token limit, suited to complex or long messages.
+- **o4-mini** – faster reasoning model that still handles nuanced cases well.
+
+When using `o3` or `o4-mini` you can raise `thinking-effort` in `config.yml`
+to improve accuracy.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ For reasoning models (`o3`, `o4-mini`), the `thinking-effort` option controls
 the reasoning effort used (`low`, `medium`, or `high`). These models have no
 token limit, while standard chat models are capped at **five** tokens to avoid
 OpenAI errors.
+### Choosing a Model
+
+See [MODEL_GUIDE.md](MODEL_GUIDE.md) for a quick reference on each model.
+
+- **omni-moderation-latest** – fast and inexpensive moderation endpoint (default).
+- **gpt-4.1-mini** – lightweight chat model for extra nuance at a lower cost.
+- **gpt-4.1** – more capable chat model offering the highest accuracy.
+- **o3** – reasoning model with no token limit, suitable for complex messages.
+- **o4-mini** – faster reasoning model that still handles nuanced cases.
+
+Increase `thinking-effort` if you pick `o3` or `o4-mini` for better results.
 All categories supported by this model are included in `blocked-categories`:
 
 ```

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,7 +1,13 @@
 openai-key: "REPLACE_ME"
 language: en
 prefix: "&7[ChatModeration] &r"
-# Set to 'gpt-4.1-mini', 'gpt-4.1', 'o3' or 'o4-mini' to use the chat model with a profanity check prompt
+# Available models:
+#  omni-moderation-latest - default moderation endpoint, fast and cheap
+#  gpt-4.1-mini          - lightweight chat model for extra nuance
+#  gpt-4.1               - full chat model with higher accuracy
+#  o3                    - reasoning model, no token limit
+#  o4-mini               - faster but still reasoning capable
+# Set one of these to use the chat completion API instead of the moderation endpoint
 model: omni-moderation-latest
 # Prompt used by the chat model
 chat-prompt: "Sen minecraft sohbet moderatörüsün. Görevin Türkçe cümlede küfür veya hakaret varsa sadece var yoksa yok yaz (lan, altıma sıçtım gibi basit argo kelimeleri ve lezyiyen gibi nicknameleri ve minecraft sunucularında kullanılan terimleri görmezden gel sadece kullanıcıların birbirlerine doğrudan küfür ve hakaret emlerine izin vermeyeceksin) (kullanıcı küfürü gizlemek için özel karakterler veya sansürler kullanmış olabilir dikkat et):"


### PR DESCRIPTION
## Summary
- elaborate README section on choosing a model and reference a new guide
- document model choices directly in `config.yml`
- add `MODEL_GUIDE.md` with a concise overview of available OpenAI models

## Testing
- `gradle wrapper --no-daemon --console=plain`
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685b2c18e6ec8330910cc15a7688abf4