### PR TITLE
Fix anvil GUI rename handling

### DIFF
--- a/src/main/java/me/ogulcan/chatmod/gui/AddWordGUI.java
+++ b/src/main/java/me/ogulcan/chatmod/gui/AddWordGUI.java
@@ -42,11 +42,17 @@ public class AddWordGUI implements Listener {
     @EventHandler
     public void onPrepare(PrepareAnvilEvent e) {
         if (!e.getInventory().equals(inventory)) return;
-        ItemStack result = e.getResult();
-        if (result != null && result.hasItemMeta() && result.getItemMeta().hasDisplayName()) {
-            renameText = ChatColor.stripColor(result.getItemMeta().getDisplayName());
+        renameText = e.getInventory().getRenameText();
+        ItemStack base = e.getInventory().getItem(0);
+        if (base != null && renameText != null && !renameText.isBlank()) {
+            ItemStack result = base.clone();
+            ItemMeta meta = result.getItemMeta();
+            meta.setDisplayName(renameText);
+            result.setItemMeta(meta);
+            e.setResult(result);
+            e.getInventory().setRepairCost(0);
         } else {
-            renameText = null;
+            e.setResult(null);
         }
     }
 


### PR DESCRIPTION
## Summary
- allow blocking words to be added without XP cost

## Testing
- `gradle test --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_685b372fe1808330a57c07d01cde6adb