### PR TITLE
Fix AddWordGUI cast

### DIFF
--- a/src/main/java/me/ogulcan/chatmod/gui/AddWordGUI.java
+++ b/src/main/java/me/ogulcan/chatmod/gui/AddWordGUI.java
@@ -65,9 +65,10 @@ public class AddWordGUI implements Listener {
         if (!e.getView().getTopInventory().equals(inventory)) return;
         if (e.getRawSlot() == 2) {
             e.setCancelled(true);
-            AnvilInventory anvil = (AnvilInventory) e.getView().getTopInventory();
-            String text = anvil.getRenameText();
-            if (text != null) renameText = text;
+            if (e.getView().getTopInventory() instanceof AnvilInventory anvil) {
+                String text = anvil.getRenameText();
+                if (text != null) renameText = text;
+            }
             if (renameText != null && !renameText.isBlank()) {
                 boolean added = plugin.addBlockedWord(renameText);
                 saved = true;


### PR DESCRIPTION
## Summary
- fix cast check in `AddWordGUI` so server won't crash

## Testing
- `gradle wrapper`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_685b452a3be08330b6d65d08e47ca809