### PR TITLE
Fix blocked word saving

### DIFF
--- a/src/main/java/me/ogulcan/chatmod/Main.java
+++ b/src/main/java/me/ogulcan/chatmod/Main.java
@@ -258,6 +258,9 @@ public class Main extends JavaPlugin {
 
     public synchronized boolean addBlockedWord(String word) {
         if (blockedWordsFile == null) return false;
+        if (!blockedWordsFile.getParentFile().exists()) {
+            blockedWordsFile.getParentFile().mkdirs();
+        }
         org.bukkit.configuration.file.YamlConfiguration cfg =
                 org.bukkit.configuration.file.YamlConfiguration.loadConfiguration(blockedWordsFile);
         java.util.List<String> words = cfg.getStringList("blocked-words");
@@ -269,7 +272,11 @@ public class Main extends JavaPlugin {
         }
         words.add(word);
         cfg.set("blocked-words", words);
-        try { cfg.save(blockedWordsFile); } catch (Exception ignored) {}
+        try {
+            cfg.save(blockedWordsFile);
+        } catch (Exception e) {
+            getLogger().warning("Failed to save blocked words: " + e.getMessage());
+        }
         wordsLastModified = blockedWordsFile.lastModified();
         if (chatListener != null) chatListener.updateBlockedWords(words);
         return true;
@@ -277,6 +284,9 @@ public class Main extends JavaPlugin {
 
     public synchronized boolean removeBlockedWord(String word) {
         if (blockedWordsFile == null) return false;
+        if (!blockedWordsFile.getParentFile().exists()) {
+            blockedWordsFile.getParentFile().mkdirs();
+        }
         org.bukkit.configuration.file.YamlConfiguration cfg =
                 org.bukkit.configuration.file.YamlConfiguration.loadConfiguration(blockedWordsFile);
         java.util.List<String> words = cfg.getStringList("blocked-words");
@@ -291,7 +301,11 @@ public class Main extends JavaPlugin {
         if (found == null) return false;
         words.remove(found);
         cfg.set("blocked-words", words);
-        try { cfg.save(blockedWordsFile); } catch (Exception ignored) {}
+        try {
+            cfg.save(blockedWordsFile);
+        } catch (Exception e) {
+            getLogger().warning("Failed to save blocked words: " + e.getMessage());
+        }
         wordsLastModified = blockedWordsFile.lastModified();
         if (chatListener != null) chatListener.updateBlockedWords(words);
         return true;

--- a/src/test/java/me/ogulcan/chatmod/AddBlockedWordTest.java
+++ b/src/test/java/me/ogulcan/chatmod/AddBlockedWordTest.java
@@ -1,0 +1,38 @@
+package me.ogulcan.chatmod;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import me.ogulcan.chatmod.Main;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AddBlockedWordTest {
+    private Main plugin;
+
+    @BeforeEach
+    public void setUp() {
+        MockBukkit.mock();
+        plugin = MockBukkit.load(Main.class);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    public void testAddBlockedWordPersistsToFile() {
+        File file = plugin.getBlockedWordsFile();
+        assertNotNull(file, "Blocked words file should not be null");
+        assertTrue(plugin.addBlockedWord("foobar"));
+        YamlConfiguration cfg = YamlConfiguration.loadConfiguration(file);
+        List<String> words = cfg.getStringList("blocked-words");
+        assertTrue(words.contains("foobar"));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure blocked word file directory exists and warn if file can't be saved
- add test to verify blocked words persist to file

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_685b489de23c8330b802823707fc7701