### PR TITLE
Fix AddWord GUI rename capture

### DIFF
--- a/src/main/java/me/ogulcan/chatmod/gui/AddWordGUI.java
+++ b/src/main/java/me/ogulcan/chatmod/gui/AddWordGUI.java
@@ -83,6 +83,12 @@ public class AddWordGUI implements Listener {
                 String text = anvil.getRenameText();
                 if (text != null) renameText = text;
             }
+            if ((renameText == null || renameText.isBlank()) && e.getCurrentItem() != null) {
+                ItemStack item = e.getCurrentItem();
+                if (item.hasItemMeta() && item.getItemMeta().hasDisplayName()) {
+                    renameText = ChatColor.stripColor(item.getItemMeta().getDisplayName());
+                }
+            }
             if (renameText != null && !renameText.isBlank()) {
                 me.ogulcan.chatmod.AddWordResult result = plugin.addBlockedWord(renameText);
                 saved = true;


### PR DESCRIPTION
## Summary
- improve AddWordGUI rename handling by reading currentItem when rename text is missing

## Testing
- `gradle wrapper --no-daemon`
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685b6087fbac833081cfdb4835f25462