### PR TITLE
Fix anvil GUI check for adding blocked words

### DIFF
--- a/src/main/java/me/ogulcan/chatmod/gui/AddWordGUI.java
+++ b/src/main/java/me/ogulcan/chatmod/gui/AddWordGUI.java
@@ -47,7 +47,7 @@ public class AddWordGUI implements Listener {
 
     @EventHandler
     public void onPrepare(PrepareAnvilEvent e) {
-        if (!e.getInventory().equals(inventory)) return;
+        if (!e.getView().getTopInventory().equals(inventory)) return;
         handlePrepare(e.getInventory(), e);
     }
 


### PR DESCRIPTION
## Summary
- fix inventory check for `PrepareAnvilEvent`

## Testing
- `gradle wrapper`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_685b656f251c8330abdc2f80bd0adfb0